### PR TITLE
fix breaking type for useNinetailed react hook

### DIFF
--- a/packages/sdks/react/src/lib/useNinetailed.ts
+++ b/packages/sdks/react/src/lib/useNinetailed.ts
@@ -1,8 +1,8 @@
 import { useContext } from 'react';
-
+import { NinetailedInstance } from '@ninetailed/experience.js';
 import { NinetailedContext } from './NinetailedContext';
 
-export const useNinetailed = () => {
+export const useNinetailed = (): NinetailedInstance => {
   const ninetailed = useContext(NinetailedContext);
 
   if (ninetailed === undefined) {


### PR DESCRIPTION
After a recent NX upgrade to latest minor 15.9.7, we noticed a type failing because of a wrong import:

`// from dist folder, generated type`
<img width="830" alt="Screenshot 2024-01-11 at 12 35 44" src="https://github.com/ninetailed-inc/experience.js/assets/32224751/ad4c711c-fb63-4b8c-898e-fe6e509ce66c">

Removing the type inference and forcing the return type solves the issue:

`// from dist folder, generated type`
<img width="894" alt="Screenshot 2024-01-11 at 12 35 25" src="https://github.com/ninetailed-inc/experience.js/assets/32224751/a86775bf-92a1-4af8-b402-35116209cf93">

