### PR TITLE
ci: prepare bump and publish from the CI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,221 @@
+name: Publish packages
+on:
+  release:
+    types: [published]
+jobs:
+  setup:
+    name: Yarn install 🛠️
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+
+      # node_module cache helps to avoid 1 minute copying from yarn cache on every job run
+      - name: node_modules cache
+        id: node-modules-cache
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: ${{ runner.os }}-node-modules-yarn-
+
+      - name: Yarn install
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: yarn install --prefer-offline --frozen-lockfile
+
+  build:
+    name: Build 📦
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: setup
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Restore node_modules from cache
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-yarn-${{ hashFiles('yarn.lock') }}
+
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        uses: nrwl/nx-set-shas@v3
+
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v2
+
+      - name: Build 📦
+        run: >
+          doppler run --mount .env -- yarn nx run-many --target=build
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+
+  lint:
+    name: Lint 🎨
+    runs-on: ubuntu-latest
+    needs: setup
+    timeout-minutes: 15
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          # fetch-depth gives the complete git history which is needed for nx.
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Restore node_modules from cache
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-yarn-${{ hashFiles('yarn.lock') }}
+
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        uses: nrwl/nx-set-shas@v3
+
+      - name: Check Format
+        run: yarn nx format:check
+
+      - name: Lint 🎨
+        run: yarn nx affected --target=lint
+
+  tests:
+    name: Tests 🧪
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: setup
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Restore node_modules from cache
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-yarn-${{ hashFiles('yarn.lock') }}
+
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        uses: nrwl/nx-set-shas@v3
+
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v2
+
+      - name: Test 🧪
+        run: >
+          doppler run --mount .env -- yarn nx affected --target=test
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+
+  license-check:
+    name: License check 📄
+    runs-on: ubuntu-latest
+    needs: setup
+    timeout-minutes: 15
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            lock:
+              - 'yarn.lock'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Restore node_modules from cache
+        uses: actions/cache@v3
+        if: steps.filter.outputs.lock == 'true'
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-yarn-${{ hashFiles('yarn.lock') }}
+
+      - name: Run License Checker
+        if: steps.filter.outputs.lock == 'true'
+        run: >
+          echo "In case of error, please check ./docs/Licenses.md"
+          yarn license-checker \
+          --summary \
+          --production \
+          --relativeLicensePath \
+          --onlyAllow 'MIT;Apache-2.0;ISC;BSD-3-Clause;BSD-2-Clause;MIT*;Apache 2.0;Unlicense;:CC0-1.0;CC-BY-4.0;WTFPL;0BSD;UNLICENSED;Python-2.0;MPL-2.0;CC-BY-3.0;CC0-1.0'
+
+  publish:
+    name: Publish to NPM 🚀
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - build
+      - lint
+      - tests
+      - license-check
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Restore node_modules from cache
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-yarn-${{ hashFiles('yarn.lock') }}
+
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v2
+
+      - name: Echo github event release metadatas
+        run: echo "$JOB_CONTEXT"
+        env:
+          JOB_CONTEXT: ${{ toJson(github.event.release) }}
+
+      - run: doppler run --mount .env -- yarn publish:packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TAG: ${{ github.event.release.tag_name }}
+          # we run nx build in the script, so we might need some env vars
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test-all": "nx run-many --target=test --all --skip-nx-cache",
     "generate:doc": "ts-node -P ./tools/scripts/tsconfig.scripts.json ./tools/scripts/documentation/generate-documentation.ts",
     "prepare": "husky install",
-    "license:add": "ts-node -P ./tools/scripts/tsconfig.scripts.json ./tools/scripts/add-license.ts"
+    "license:add": "ts-node -P ./tools/scripts/tsconfig.scripts.json ./tools/scripts/add-license.ts",
+    "publish:packages": "./tools/bump_and_publish_sdks.sh"
   },
   "private": true,
   "dependencies": {

--- a/tools/bump_and_publish_sdks.sh
+++ b/tools/bump_and_publish_sdks.sh
@@ -1,10 +1,40 @@
 #! /bin/bash
 
+# Script to bump and publish all packages defined in the BUMP_LIST.
+#
+# 2 modes are available: CI and CLI.
+#   CI: run with the CI=true flag to automatically bump to the GITHUB_TAG
+#       version (automatically set in git).
+#       To use this mode, create a release from Github release UI, and the 
+#       pipeline will automatically run.
+#       Note: this mode will add signed provenance to the NPM packages.
+#       Example to run in CI mode:
+#         `CI=true GITHUB_TAG=1.1.0-beta DRY_RUN=true ./tools/bump_and_publish_sdks.sh`
+#   CLI: Run from a local laptop, for admin only. Interactive Shell allowing
+#        to choose the version bumping strategy.
+#        Example to run in CLI mode:
+#         `DRY_RUN=true ./tools/bump_and_publish_sdks.sh`
+
+
+# set -e to exit on error
+# set -u to exit on undefined variable
+# set -o pipefail to exit on pipe fails
 set -euo pipefail
 
+# Add NPM --dry-run flag if DRY_RUN is set to trie
+if [ "$DRY_RUN" = "true" ]; then
+  DRY_RUN_FLAG="--dry-run"
+else
+  DRY_RUN_FLAG=""
+fi
+
+#############
+# Functions #
+#############
 function bump_and_publish () {
   if [ "$#" -ne 1 ]; then
     echo "Illegal number of parameters for bump_and_publish"
+    exit 1
   fi
   path_after_packages=$1
   nx_project_name=$(echo $1 | sed -E 's/\//-/g')
@@ -21,11 +51,20 @@ function bump_and_publish () {
   cd $PROJECT_ROOT
   yarn nx build $nx_project_name
   # publish once built
-  cd dist/Packages/$path_after_packages
-  npm publish --access public --tag $RELEASE_TAG
+  cd dist/packages/$path_after_packages
+
+  # If runs from GHA pipeline, we add provenance to the package.
+  # https://docs.npmjs.com/generating-provenance-statements
+  if [ "$CI" = "true" ]; then
+    npm publish $DRY_RUN_FLAG --provenance --access public --tag $RELEASE_TAG 
+  else
+    npm publish $DRY_RUN_FLAG --access public --tag $RELEASE_TAG
+  fi
 }
 
-# TODO: make sure we're at project root
+########
+# Main #
+########
 if [ -d .git ]; then
   # okay!
   :
@@ -42,50 +81,73 @@ then
     exit 1
 fi
 
-CURRENT_VERSION=$(cat packages/sdks/javascript/package.json | jq -r '.["version"]')
-echo ">> Current version: $CURRENT_VERSION"
-echo "What do you want to do?"
-echo "(0) ==.==.==.beta+1 (default)"
-echo "(1) ==.==.+1.beta0"
-echo "(2) ==.==.+1"
-echo "(3) ==.+1.0.beta0"
-echo "(4) ==.+1.0"
-read choice
-if [ "$choice" = "" ]; then
-  BUMP_FLAGS="prerelease --preid=beta"
-  RELEASE_TAG=beta
-elif  [ "$choice" = "0" ]; then
-  BUMP_FLAGS="prerelease --preid=beta"
-  RELEASE_TAG=beta
-elif  [ "$choice" = "1" ]; then
-  BUMP_FLAGS="prepatch --preid=beta"
-  RELEASE_TAG=beta
-elif  [ "$choice" = "2" ]; then
-  BUMP_FLAGS="patch"
-  RELEASE_TAG=latest
-elif  [ "$choice" = "3" ]; then
-  BUMP_FLAGS="preminor --preid=beta"
-  RELEASE_TAG=beta
-elif  [ "$choice" = "4" ]; then
-  BUMP_FLAGS="minor"
-  RELEASE_TAG=latest
+# check if it is running in CI
+# (variable automatically set to true in github)
+if [ "${CI:-}" = "true" ]; then
+  echo "[i] Running in CI mode"
+
+  if [ -z "$GITHUB_TAG" ]; then
+    echo "GITHUB_TAG is not set. It needs to be set when run with the CI flag."
+  else
+    echo "[i] GITHUB_TAG is set to $GITHUB_TAG"
+  fi
+
+  NEW_VERSION=$GITHUB_TAG
+
+  # if the tag contains beta, we publish to the beta tag on NPM
+  if [[ $GITHUB_TAG == *"beta"* ]]; then
+    RELEASE_TAG="beta"
+  else
+    # otherwise we use latest
+    RELEASE_TAG="latest"
+  fi
+# otherwise, we run in interactive CLI mode
+else
+  CURRENT_VERSION=$(cat packages/sdks/javascript/package.json | jq -r '.["version"]')
+  echo ">> Current version: $CURRENT_VERSION"
+  echo "What do you want to do?"
+  echo "(0) ==.==.==.beta+1 (default)"
+  echo "(1) ==.==.+1.beta0"
+  echo "(2) ==.==.+1"
+  echo "(3) ==.+1.0.beta0"
+  echo "(4) ==.+1.0"
+  read choice
+  if [ "$choice" = "" ]; then
+    BUMP_FLAGS="prerelease --preid=beta"
+    RELEASE_TAG=beta
+  elif  [ "$choice" = "0" ]; then
+    BUMP_FLAGS="prerelease --preid=beta"
+    RELEASE_TAG=beta
+  elif  [ "$choice" = "1" ]; then
+    BUMP_FLAGS="prepatch --preid=beta"
+    RELEASE_TAG=beta
+  elif  [ "$choice" = "2" ]; then
+    BUMP_FLAGS="patch"
+    RELEASE_TAG=latest
+  elif  [ "$choice" = "3" ]; then
+    BUMP_FLAGS="preminor --preid=beta"
+    RELEASE_TAG=beta
+  elif  [ "$choice" = "4" ]; then
+    BUMP_FLAGS="minor"
+    RELEASE_TAG=latest
+  fi
+
+  # bump up one package to get new version string
+  cd packages/sdks/shared
+  npm version $BUMP_FLAGS > /dev/null
+  NEW_VERSION=$(cat package.json | jq -r '.["version"]')
+  # we will revisit javascript and treat it the same
+
+  echo ">> Bumping to $NEW_VERSION and publishing..."
+  sleep 1
+  echo -ne "Here "
+  sleep 1
+  echo -ne "we "
+  sleep 1
+  echo -ne "go!"
+  sleep 1
+  printf "\n\n"
 fi
-
-# bump up one package to get new version string
-cd packages/sdks/shared
-npm version $BUMP_FLAGS > /dev/null
-NEW_VERSION=$(cat package.json | jq -r '.["version"]')
-# we will revisit javascript and treat it the same
-
-echo ">> Bumping to $NEW_VERSION and publishing..."
-sleep 1
-echo -ne "Here "
-sleep 1
-echo -ne "we "
-sleep 1
-echo -ne "go!"
-sleep 1
-printf "\n\n"
 
 BUMP_LIST=(
   # sdks
@@ -118,4 +180,4 @@ for i in "${BUMP_LIST[@]}"; do
 done
 
 # arrived here? we good!
-echo "Shiny! Everything at $NEW_VERSION"
+echo "[✔️] Shiny! Everything at $NEW_VERSION"


### PR DESCRIPTION
Add the bump and publish workflow on the `release published` event of Github to automate the release process.

We can then create new release from Github UI, which will trigger a complete CI run + NPM publish of our packages.

The CI workflow was tested on our private legacy repo.

<img width="916" alt="Screenshot 2024-01-11 at 17 28 29" src="https://github.com/ninetailed-inc/experience.js/assets/32224751/b607716b-a2a9-43e4-8126-fe6480d98212">
