### PR TITLE
ci: fix wrong .npmrc config

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -204,7 +204,7 @@ jobs:
         env:
           JOB_CONTEXT: ${{ toJson(github.event.release) }}
 
-      - run: doppler run --mount .env -- yarn publish:packages
+      - run: doppler run --mount .env -- ./tools/bump_and_publish_sdks.sh
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TAG: ${{ github.event.release.tag_name }}

--- a/tools/bump_and_publish_sdks.sh
+++ b/tools/bump_and_publish_sdks.sh
@@ -79,6 +79,11 @@ else
 fi
 PROJECT_ROOT=$(pwd)
 
+# debug local configuration
+echo "[i] print debug .npmrc"
+cat $PROJECT_ROOT/.npmrc
+echo ""
+
 if ! command -v jq &> /dev/null
 then
     echo "jq could not be found"


### PR DESCRIPTION
using `yarn` seems to use a different registry URL than NPM.

- do not use a yarn command to run the publish script
- printout the npmrc to have more insights on what is used