### PR TITLE
ci: give correct permissions for provenance

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -172,6 +172,10 @@ jobs:
     name: Publish to NPM 🚀
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      id-token: write # This is required for NPM provenance on publish
+      contents: read # To checkout the repo
+      actions: read
     needs:
       - build
       - lint


### PR DESCRIPTION
On publish workflow, we were missing some rights from the CI to publish with provenance to NPM.

```sh
npm notice Publishing to https://registry.npmjs.org/ with tag beta and public access
npm ERR! code EUSAGE
npm ERR! Provenance generation in GitHub Actions requires "write" access to the "id-token" permission
```