### PR TITLE
Fix release CI by adding a repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "test-all": "nx run-many --target=test --all --skip-nx-cache",
     "generate:doc": "ts-node -P ./tools/scripts/tsconfig.scripts.json ./tools/scripts/documentation/generate-documentation.ts",
     "prepare": "husky install",
-    "license:add": "ts-node -P ./tools/scripts/tsconfig.scripts.json ./tools/scripts/add-license.ts",
-    "publish:packages": "./tools/bump_and_publish_sdks.sh"
+    "license:add": "ts-node -P ./tools/scripts/tsconfig.scripts.json ./tools/scripts/add-license.ts"
   },
   "private": true,
   "dependencies": {

--- a/packages/plugins/analytics/package.json
+++ b/packages/plugins/analytics/package.json
@@ -4,5 +4,10 @@
   "type": "commonjs",
   "devDependencies": {},
   "description": "Ninetailed SDK plugin for analytics",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetailed-inc/experience.js.git",
+    "directory": "packages/plugins/analytics"
+  }
 }

--- a/packages/plugins/contentsquare/package.json
+++ b/packages/plugins/contentsquare/package.json
@@ -4,5 +4,10 @@
   "type": "commonjs",
   "devDependencies": {},
   "description": "Ninetailed SDK plugin for Contentsquare",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetailed-inc/experience.js.git",
+    "directory": "packages/plugins/contentsquare"
+  }
 }

--- a/packages/plugins/google-analytics/package.json
+++ b/packages/plugins/google-analytics/package.json
@@ -3,5 +3,10 @@
   "version": "7.5.1",
   "devDependencies": {},
   "description": "Ninetailed SDK plugin for Google Analytics",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetailed-inc/experience.js.git",
+    "directory": "packages/plugins/google-analytics"
+  }
 }

--- a/packages/plugins/google-tagmanager/package.json
+++ b/packages/plugins/google-tagmanager/package.json
@@ -4,5 +4,10 @@
   "type": "commonjs",
   "devDependencies": {},
   "description": "Ninetailed SDK plugin for Google Tag Manager",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetailed-inc/experience.js.git",
+    "directory": "packages/plugins/google-tagmanager"
+  }
 }

--- a/packages/plugins/insights/package.json
+++ b/packages/plugins/insights/package.json
@@ -3,5 +3,10 @@
   "version": "7.5.1",
   "type": "commonjs",
   "description": "Ninetailed SDK plugin for Adobe Analytics",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetailed-inc/experience.js.git",
+    "directory": "packages/plugins/insights"
+  }
 }

--- a/packages/plugins/preview-bridge/package.json
+++ b/packages/plugins/preview-bridge/package.json
@@ -2,5 +2,10 @@
   "name": "@ninetailed/experience.js-preview-bridge",
   "description": "Ninetailed SDK plugin for Experience.js preview bridge",
   "version": "7.5.1",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetailed-inc/experience.js.git",
+    "directory": "packages/plugins/preview-bridge"
+  }
 }

--- a/packages/plugins/preview/package.json
+++ b/packages/plugins/preview/package.json
@@ -2,5 +2,10 @@
   "name": "@ninetailed/experience.js-plugin-preview",
   "version": "7.5.1",
   "description": "Ninetailed SDK plugin for preview",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetailed-inc/experience.js.git",
+    "directory": "packages/plugins/preview"
+  }
 }

--- a/packages/plugins/privacy/package.json
+++ b/packages/plugins/privacy/package.json
@@ -2,6 +2,10 @@
   "name": "@ninetailed/experience.js-plugin-privacy",
   "version": "7.5.1",
   "description": "Ninetailed SDK plugin for privacy",
-  "devDependencies": {},
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetailed-inc/experience.js.git",
+    "directory": "packages/plugins/privacy"
+  }
 }

--- a/packages/plugins/segment/package.json
+++ b/packages/plugins/segment/package.json
@@ -3,6 +3,10 @@
   "version": "7.5.1",
   "type": "commonjs",
   "description": "Ninetailed SDK plugin for Segment",
-  "devDependencies": {},
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetailed-inc/experience.js.git",
+    "directory": "packages/plugins/segment"
+  }
 }

--- a/packages/plugins/ssr/package.json
+++ b/packages/plugins/ssr/package.json
@@ -2,5 +2,10 @@
   "name": "@ninetailed/experience.js-plugin-ssr",
   "version": "7.5.1",
   "description": "Ninetailed SDK plugin for SSR",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetailed-inc/experience.js.git",
+    "directory": "packages/plugins/ssr"
+  }
 }

--- a/packages/sdks/gatsby/package.json
+++ b/packages/sdks/gatsby/package.json
@@ -14,5 +14,10 @@
     "react": ">=16.8.0",
     "gatsby": ">=2.27.4"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetailed-inc/experience.js.git",
+    "directory": "packages/plugins/gatsby"
+  },
   "license": "MIT"
 }

--- a/packages/sdks/javascript/package.json
+++ b/packages/sdks/javascript/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ninetailed/experience.js",
-  "version": "7.5.1",
+  "version": "7.5.2-beta.1",
   "description": "Ninetailed SDK for javascript",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetailed-inc/experience.js.git",
+    "directory": "packages/sdks/javascript"
+  }
 }

--- a/packages/sdks/nextjs-esr/package.json
+++ b/packages/sdks/nextjs-esr/package.json
@@ -5,5 +5,10 @@
   "dependencies": {
     "next": "12.1.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetailed-inc/experience.js.git",
+    "directory": "packages/sdks/nextjs-esr"
+  }
 }

--- a/packages/sdks/nextjs/package.json
+++ b/packages/sdks/nextjs/package.json
@@ -6,5 +6,10 @@
     "next": ">=9.0.0",
     "react": ">=16.8.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetailed-inc/experience.js.git",
+    "directory": "packages/sdks/nextjs"
+  }
 }

--- a/packages/sdks/nodejs/package.json
+++ b/packages/sdks/nodejs/package.json
@@ -6,6 +6,10 @@
     "node-fetch": "2",
     "uuid": "^8.3.2"
   },
-  "devDependencies": {},
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetailed-inc/experience.js.git",
+    "directory": "packages/sdks/nodejs"
+  }
 }

--- a/packages/sdks/react/package.json
+++ b/packages/sdks/react/package.json
@@ -5,5 +5,10 @@
   "peerDependencies": {
     "react": ">=16.8.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetailed-inc/experience.js.git",
+    "directory": "packages/sdks/react"
+  }
 }

--- a/packages/sdks/shared/package.json
+++ b/packages/sdks/shared/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@ninetailed/experience.js-shared",
-  "version": "7.5.1",
+  "version": "7.5.2-beta.1",
   "description": "Shared code for Experience.js",
-  "devDependencies": {},
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetailed-inc/experience.js.git",
+    "directory": "packages/sdks/shared"
+  }
 }

--- a/packages/utils/contentful/package.json
+++ b/packages/utils/contentful/package.json
@@ -6,5 +6,10 @@
     "contentful": "^9.1.32",
     "@contentful/rich-text-types": "16.2.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetailed-inc/experience.js.git",
+    "directory": "packages/utils/contentful"
+  }
 }

--- a/packages/utils/javascript/package.json
+++ b/packages/utils/javascript/package.json
@@ -2,6 +2,10 @@
   "name": "@ninetailed/experience.js-utils",
   "version": "7.5.1",
   "description": "Ninetailed Experience.js Utils",
-  "devDependencies": {},
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetailed-inc/experience.js.git",
+    "directory": "packages/utils/javascript"
+  }
 }


### PR DESCRIPTION
- ci: add `repository` field to all package.json to match with requirements from the NPM provenance flag
  - https://docs.npmjs.com/generating-provenance-statements#prerequisites
  - https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository 
- chore: add a check to skip provenance flag when publishing if the repository field is missing from the package.json
  - it should prevent the CI failing on future new packages if we forget the set the field
- fix: remove publish:packages from yarn script
  - publish should be run without yarn to match the content (registry field) set by node-setup in the CI