### PR TITLE
fix: observe empty variant components

### DIFF
--- a/packages/sdks/react/src/lib/Experience/ComponentMarker.tsx
+++ b/packages/sdks/react/src/lib/Experience/ComponentMarker.tsx
@@ -2,42 +2,70 @@ import React, { forwardRef, useEffect, useRef } from 'react';
 
 import { useNinetailed } from '../useNinetailed';
 
-export const ComponentMarker = forwardRef((_, ref) => {
-  const { logger } = useNinetailed();
-  const markerRef = useRef<HTMLDivElement | null>(null);
+type ComponentMarkerProps = {
+  hidden?: boolean;
+};
 
-  useEffect(() => {
-    /*
+export const ComponentMarker = forwardRef<unknown, ComponentMarkerProps>(
+  ({ hidden = false }, ref) => {
+    const { logger } = useNinetailed();
+    const markerRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+      /*
     Due to React's limitation on setting !important styles during rendering, we set the display property on the DOM element directly.
     See: https://github.com/facebook/react/issues/1881
     */
-    markerRef.current?.style.setProperty('display', 'none', 'important');
-  }, []);
+      markerRef.current?.style.setProperty('display', 'none', 'important');
+    }, []);
 
-  useEffect(() => {
-    logger.debug(
-      'Using fallback mechanism to detect when experiences are seen. This can lead to inaccurate results. Consider using a forwardRef instead. See: https://docs.ninetailed.io/for-developers/experience-sdk/rendering-experiences#tracking-impressions-of-experiences'
-    );
-  }, [logger]);
+    useEffect(() => {
+      logger.debug(
+        'Using fallback mechanism to detect when experiences are seen. This can lead to inaccurate results. Consider using a forwardRef instead. See: https://docs.ninetailed.io/for-developers/experience-sdk/rendering-experiences#tracking-impressions-of-experiences'
+      );
+    }, [logger]);
 
-  useEffect(() => {
-    if (markerRef.current) {
-      const nextSibling = markerRef.current.nextSibling;
-      if (ref) {
-        if (typeof ref === 'function') {
-          ref(nextSibling);
-        } else {
-          ref.current = nextSibling;
+    useEffect(() => {
+      if (markerRef.current) {
+        const nextSibling = getNextSibling(markerRef.current, hidden);
+
+        if (ref) {
+          if (typeof ref === 'function') {
+            ref(nextSibling);
+          } else {
+            ref.current = nextSibling;
+          }
         }
       }
-    }
-  }, []);
+    }, [hidden]);
 
-  return (
-    <div
-      className="nt-cmp-marker"
-      style={{ display: 'none' }}
-      ref={markerRef}
-    />
-  );
-});
+    return (
+      <div
+        className="nt-cmp-marker"
+        style={{ display: 'none' }}
+        ref={markerRef}
+      />
+    );
+  }
+);
+
+const getNextSibling = (
+  element: HTMLElement,
+  recursive = false
+): ChildNode | null => {
+  if (!recursive) {
+    return element.nextSibling;
+  }
+
+  const { parentElement } = element;
+
+  if (!parentElement) {
+    return null;
+  }
+
+  if (parentElement.nextSibling) {
+    return parentElement.nextSibling;
+  }
+
+  return getNextSibling(parentElement, true);
+};

--- a/packages/sdks/react/src/lib/Experience/Experience.tsx
+++ b/packages/sdks/react/src/lib/Experience/Experience.tsx
@@ -230,6 +230,7 @@ export const Experience = <
       <ComponentMarker
         key={`marker-hidden-${experience?.id || 'baseline'}-${variant.id}`}
         ref={componentRef}
+        hidden
       />
     );
   }


### PR DESCRIPTION
For empty variants, that don't render any DOM elements, recursively look up for an element that can be observed.