### PR TITLE
fix: fix linting by adding expected git references

### DIFF
--- a/.github/workflows/lint_build_test_all.yml
+++ b/.github/workflows/lint_build_test_all.yml
@@ -60,7 +60,7 @@ jobs:
         uses: nrwl/nx-set-shas@v3
 
       - name: Check Format
-        run: yarn nx format:check
+        run: yarn nx format:check --verbose
 
       - name: Lint 🎨
         run: yarn nx affected --target=lint

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -89,8 +89,11 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-node-modules-yarn-${{ hashFiles('yarn.lock') }}
 
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        uses: nrwl/nx-set-shas@v3
+
       - name: Check Format
-        run: yarn nx format:check
+        run: yarn nx format:check --verbose
 
       - name: Lint 🎨
         run: yarn nx run-many --target=lint


### PR DESCRIPTION
By default the format command seems to expect --base and --head flags added by the nrwl/nx-set-shas@v3 actions