### PR TITLE
fix: add missing plugin options in Gatsby schema

### DIFF
--- a/packages/sdks/gatsby/gatsby-node.tsx
+++ b/packages/sdks/gatsby/gatsby-node.tsx
@@ -28,6 +28,8 @@ export const pluginOptionsSchema = ({
     environment: Joi.string(),
     ninetailedPlugins: Joi.array(),
     useClientSideEvaluation: Joi.boolean().optional().default(false),
+    onInitProfileId: Joi.function().optional(),
+    onRouteChange: Joi.function().optional(),
   });
 };
 


### PR DESCRIPTION
Using those options results in a warning since they're not part of the `pluginOptionsSchema`. 

