### PR TITLE
DEV-3409-sdk-pass-package-version-to-preview-plugin-api

### DIFF
--- a/packages/plugins/preview/src/lib/plugin/NinetailedPreviewPlugin.ts
+++ b/packages/plugins/preview/src/lib/plugin/NinetailedPreviewPlugin.ts
@@ -364,7 +364,7 @@ export class NinetailedPreviewPlugin
 
   private get pluginApi(): PreviewPluginApi {
     return {
-      version: '2.0.0',
+      version: process.env['NX_PACKAGE_VERSION'] || '0.0.0',
 
       open: this.open.bind(this),
       close: this.close.bind(this),


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- The `NinetailedPreviewPlugin` class now dynamically sets its version based on the `NX_PACKAGE_VERSION` environment variable, defaulting to '0.0.0' if the environment variable is not set. This enhancement allows for more flexibility and automation in version management within the preview plugin API.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NinetailedPreviewPlugin.ts</strong><dd><code>Dynamically Set Plugin API Version from Environment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/plugins/preview/src/lib/plugin/NinetailedPreviewPlugin.ts

<li>Updated the <code>version</code> property in <code>pluginApi</code> to dynamically fetch the <br>package version from environment variables, defaulting to '0.0.0' if <br>not available.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/44/files#diff-d5424c668eb7dec32a53911da8a08152a68bfa0c88c2978b764be1a297ef7f67">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

