### PR TITLE
DEV-3658 Add option to filter events and deactivate features even if consent is given

### DIFF
--- a/packages/plugins/google-tagmanager/package.json
+++ b/packages/plugins/google-tagmanager/package.json
@@ -3,9 +3,9 @@
   "version": "7.6.0-beta.1",
   "type": "commonjs",
   "dependencies": {
-    "@ninetailed/experience.js": "7.5.2-beta.1",
+    "@ninetailed/experience.js": "*",
     "@ninetailed/experience.js-plugin-analytics": "*",
-    "@ninetailed/experience.js-shared": "7.5.2-beta.1",
+    "@ninetailed/experience.js-shared": "*",
     "tslib": "2.4.1"
   },
   "description": "Ninetailed SDK plugin for Google Tag Manager",

--- a/packages/plugins/privacy/jest.config.js
+++ b/packages/plugins/privacy/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   displayName: 'plugins-privacy',
   preset: '../../../jest.preset.js',
   globals: {},
-  testEnvironment: 'node',
+  testEnvironment: 'jsdom',
   transform: {
     '^.+\\.[tj]sx?$': [
       'ts-jest',

--- a/packages/plugins/privacy/package.json
+++ b/packages/plugins/privacy/package.json
@@ -22,5 +22,8 @@
     "@ninetailed/experience.js-shared": "7.5.2-beta.1",
     "@ninetailed/experience.js-plugin-analytics": "*",
     "tslib": "2.4.1"
+  },
+  "devDependencies": {
+    "analytics": "0.8.1"
   }
 }

--- a/packages/plugins/privacy/package.json
+++ b/packages/plugins/privacy/package.json
@@ -18,8 +18,8 @@
   "dependencies": {
     "radash": "10.9.0",
     "wildcard-match": "5.1.2",
-    "@ninetailed/experience.js": "7.5.2-beta.1",
-    "@ninetailed/experience.js-shared": "7.5.2-beta.1",
+    "@ninetailed/experience.js": "*",
+    "@ninetailed/experience.js-shared": "*",
     "@ninetailed/experience.js-plugin-analytics": "*",
     "tslib": "2.4.1"
   },

--- a/packages/plugins/privacy/src/NinetailedPrivacyPlugin.spec.ts
+++ b/packages/plugins/privacy/src/NinetailedPrivacyPlugin.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { Analytics, AnalyticsInstance } from 'analytics';
+import { PLUGIN_NAME as NINETAILED_CORE_PLUGIN_NAME } from '@ninetailed/experience.js';
 import {
   FEATURES,
   SET_ENABLED_FEATURES,
@@ -14,7 +15,7 @@ import { NinetailedPlugin } from '@ninetailed/experience.js-plugin-analytics';
 import { sleep } from 'radash';
 
 class TestPlugin extends NinetailedPlugin {
-  public name = 'ninetailed';
+  public name = NINETAILED_CORE_PLUGIN_NAME;
 
   public page = jest.fn();
 

--- a/packages/plugins/privacy/src/NinetailedPrivacyPlugin.spec.ts
+++ b/packages/plugins/privacy/src/NinetailedPrivacyPlugin.spec.ts
@@ -5,7 +5,7 @@ import {
   SET_ENABLED_FEATURES,
 } from '@ninetailed/experience.js-shared';
 import {
-  DEFAULT_AFTER_CONSENT_CONFIG,
+  DEFAULT_ACCEPTED_CONSENT_CONFIG,
   DEFAULT_PRIVACY_CONFIG,
   NinetailedPrivacyPlugin,
   PrivacyConfig,
@@ -61,7 +61,9 @@ describe('NinetailedPrivacyPlugin', () => {
     // @ts-expect-error
     expect(plugin.config).toEqual(DEFAULT_PRIVACY_CONFIG);
     // @ts-expect-error
-    expect(plugin.afterConsentConfig).toEqual(DEFAULT_AFTER_CONSENT_CONFIG);
+    expect(plugin.acceptedConsentConfig).toEqual(
+      DEFAULT_ACCEPTED_CONSENT_CONFIG
+    );
   });
 
   it('Should be able to instantiate with custom configs', () => {
@@ -84,7 +86,9 @@ describe('NinetailedPrivacyPlugin', () => {
       ...customConfig,
     });
     // @ts-expect-error
-    expect(plugin.afterConsentConfig).toEqual(DEFAULT_AFTER_CONSENT_CONFIG);
+    expect(plugin.acceptedConsentConfig).toEqual(
+      DEFAULT_ACCEPTED_CONSENT_CONFIG
+    );
   });
 
   it('Should correctly accept consent', async () => {
@@ -116,6 +120,8 @@ describe('NinetailedPrivacyPlugin', () => {
       {},
       { allowedEvents: [] }
     );
+
+    // await sleep(1);
 
     await analytics.page();
     expect(testPlugin.page).toHaveBeenCalled();

--- a/packages/plugins/privacy/src/NinetailedPrivacyPlugin.spec.ts
+++ b/packages/plugins/privacy/src/NinetailedPrivacyPlugin.spec.ts
@@ -1,0 +1,128 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { Analytics, AnalyticsInstance } from 'analytics';
+import { FEATURES } from '@ninetailed/experience.js-shared';
+import {
+  DEFAULT_AFTER_CONSENT_CONFIG,
+  DEFAULT_PRIVACY_CONFIG,
+  NinetailedPrivacyPlugin,
+  PrivacyConfig,
+} from './NinetailedPrivacyPlugin';
+import { NinetailedPlugin } from '@ninetailed/experience.js-plugin-analytics';
+import { sleep } from 'radash';
+
+class TestPlugin extends NinetailedPlugin {
+  public name = 'ninetailed';
+
+  public page = jest.fn();
+}
+
+const setup = (
+  config?: Partial<PrivacyConfig>,
+  afterConsentConfig?: Partial<PrivacyConfig>
+) => {
+  const testPlugin = new TestPlugin();
+  const privacyPlugin = new NinetailedPrivacyPlugin(config, afterConsentConfig);
+  const analytics = Analytics({
+    plugins: [testPlugin, privacyPlugin],
+  });
+
+  return { analytics, testPlugin, privacyPlugin };
+};
+
+describe('NinetailedPrivacyPlugin', () => {
+  let analytics: AnalyticsInstance;
+  let testPlugin: TestPlugin;
+  let privacyPlugin: NinetailedPrivacyPlugin;
+
+  beforeEach(async () => {
+    const setupResult = setup();
+    analytics = setupResult.analytics;
+    testPlugin = setupResult.testPlugin;
+    privacyPlugin = setupResult.privacyPlugin;
+
+    await sleep(1);
+
+    // @ts-expect-error
+    privacyPlugin.consent(false);
+    // I'm not sure why we need the sleep here. The localstorage write should be synchronous.
+    await sleep(1);
+  });
+
+  it('Should be able to instantiate with default configs', () => {
+    const plugin = new NinetailedPrivacyPlugin();
+
+    expect(plugin).toBeDefined();
+
+    // @ts-expect-error
+    expect(plugin.config).toEqual(DEFAULT_PRIVACY_CONFIG);
+    // @ts-expect-error
+    expect(plugin.afterConsentConfig).toEqual(DEFAULT_AFTER_CONSENT_CONFIG);
+  });
+
+  it('Should be able to instantiate with custom configs', () => {
+    const customConfig = {
+      allowedEvents: ['page' as const, 'track' as const],
+      allowedPageEventProperties: ['*'],
+      allowedTrackEventProperties: ['*'],
+      allowedTrackEvents: ['*'],
+      allowedTraits: ['*'],
+      blockProfileMerging: false,
+      enabledFeatures: Object.values(FEATURES),
+    };
+    const plugin = new NinetailedPrivacyPlugin(customConfig);
+
+    expect(plugin).toBeDefined();
+
+    // @ts-expect-error
+    expect(plugin.config).toEqual({
+      ...DEFAULT_PRIVACY_CONFIG,
+      ...customConfig,
+    });
+    // @ts-expect-error
+    expect(plugin.afterConsentConfig).toEqual(DEFAULT_AFTER_CONSENT_CONFIG);
+  });
+
+  it('Should correctly accept consent', async () => {
+    // @ts-expect-error
+    privacyPlugin.consent(true);
+    // I'm not sure why we need the sleep here. The localstorage write should be synchronous.
+    await sleep(1);
+
+    // @ts-expect-error
+    expect(privacyPlugin.isConsentGiven()).toBeTruthy();
+  });
+
+  it('Should allow Pageview events if the config sets it as allowedEvents', async () => {
+    await analytics.page();
+
+    expect(testPlugin.page).toHaveBeenCalled();
+  });
+
+  it('Should intercept Pageview events', async () => {
+    const { testPlugin } = setup({ allowedEvents: [] });
+
+    await analytics.page();
+
+    expect(testPlugin.page).not.toHaveBeenCalled();
+  });
+
+  it("should intercept page events, if the after consent config won't allow them", async () => {
+    const { testPlugin, privacyPlugin, analytics } = setup(
+      {},
+      { allowedEvents: [] }
+    );
+
+    await analytics.page();
+    expect(testPlugin.page).toHaveBeenCalled();
+
+    // @ts-expect-error
+    privacyPlugin.consent(true);
+    // I'm not sure why we need the sleep here. The localstorage write should be synchronous.
+    await sleep(1);
+
+    testPlugin.page.mockClear();
+
+    await analytics.page();
+    expect(testPlugin.page).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
+++ b/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
@@ -127,7 +127,7 @@ export class NinetailedPrivacyPlugin extends NinetailedPlugin {
     return this._instance;
   }
 
-  private async consent(accepted: boolean) {
+  private consent(accepted: boolean) {
     if (accepted) {
       this.instance.storage.setItem(CONSENT, 'accepted');
     } else {

--- a/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
+++ b/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
@@ -96,9 +96,10 @@ export const DEFAULT_ACCEPTED_CONSENT_CONFIG: PrivacyConfig = {
   enabledFeatures: Object.values(FEATURES),
 };
 
-const PAGE_EVENT_HANDLER = `page:${NINETAILED_CORE_PLUGIN_NAME}`;
-const TRACK_EVENT_HANDLER = `track:${NINETAILED_CORE_PLUGIN_NAME}`;
-const IDENTIFY_EVENT_HANDLER = `identify:${NINETAILED_CORE_PLUGIN_NAME}`;
+const PAGE_EVENT_HANDLER = `page:${NINETAILED_CORE_PLUGIN_NAME}` as const;
+const TRACK_EVENT_HANDLER = `track:${NINETAILED_CORE_PLUGIN_NAME}` as const;
+const IDENTIFY_EVENT_HANDLER =
+  `identify:${NINETAILED_CORE_PLUGIN_NAME}` as const;
 
 export class NinetailedPrivacyPlugin extends NinetailedPlugin {
   public name = PLUGIN_NAME;

--- a/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
+++ b/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
@@ -222,8 +222,6 @@ export class NinetailedPrivacyPlugin extends NinetailedPlugin {
       modifyPayloadFn?: (payload: any, abort: () => void) => any
     ) =>
     ({ payload, abort }: { payload: any; abort: any }) => {
-      console.log('handleEventStart', this.getConfig());
-
       if (!this.getConfig().allowedEvents.includes(eventType)) {
         this.queue.push(payload);
 

--- a/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
+++ b/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
@@ -11,6 +11,7 @@ import {
   COMPONENT,
   COMPONENT_START,
   SET_ENABLED_FEATURES,
+  PLUGIN_NAME as NINETAILED_CORE_PLUGIN_NAME,
 } from '@ninetailed/experience.js';
 import wildCardMatch from 'wildcard-match';
 import { isEqual } from 'radash';
@@ -94,6 +95,10 @@ export const DEFAULT_ACCEPTED_CONSENT_CONFIG: PrivacyConfig = {
   blockProfileMerging: false,
   enabledFeatures: Object.values(FEATURES),
 };
+
+const PAGE_EVENT_HANDLER = `page:${NINETAILED_CORE_PLUGIN_NAME}`;
+const TRACK_EVENT_HANDLER = `track:${NINETAILED_CORE_PLUGIN_NAME}`;
+const IDENTIFY_EVENT_HANDLER = `identify:${NINETAILED_CORE_PLUGIN_NAME}`;
 
 export class NinetailedPrivacyPlugin extends NinetailedPlugin {
   public name = PLUGIN_NAME;
@@ -216,6 +221,8 @@ export class NinetailedPrivacyPlugin extends NinetailedPlugin {
       modifyPayloadFn?: (payload: any, abort: () => void) => any
     ) =>
     ({ payload, abort }: { payload: any; abort: any }) => {
+      console.log('handleEventStart', this.getConfig());
+
       if (!this.getConfig().allowedEvents.includes(eventType)) {
         this.queue.push(payload);
 
@@ -230,7 +237,7 @@ export class NinetailedPrivacyPlugin extends NinetailedPlugin {
     };
 
   public pageStart = this.handleEventStart('page');
-  public ['page:ninetailed'] = this.handleEventStart('page', (payload) => {
+  public [PAGE_EVENT_HANDLER] = this.handleEventStart('page', (payload) => {
     const properties = this.pickAllowedKeys(
       payload.properties,
       this.getConfig().allowedPageEventProperties
@@ -247,7 +254,7 @@ export class NinetailedPrivacyPlugin extends NinetailedPlugin {
   });
 
   public trackStart = this.handleEventStart('track');
-  public ['track:ninetailed'] = this.handleEventStart(
+  public [TRACK_EVENT_HANDLER] = this.handleEventStart(
     'track',
     (payload, abort) => {
       if (!this.getConfig().allowedTrackEvents.includes(payload.event)) {
@@ -277,7 +284,7 @@ export class NinetailedPrivacyPlugin extends NinetailedPlugin {
   );
 
   public identifyStart = this.handleEventStart('identify');
-  public ['identify:ninetailed'] = this.handleEventStart(
+  public [IDENTIFY_EVENT_HANDLER] = this.handleEventStart(
     'identify',
     (payload) => {
       const traits = this.pickAllowedKeys(

--- a/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
+++ b/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
@@ -13,7 +13,7 @@ import {
   SET_ENABLED_FEATURES,
 } from '@ninetailed/experience.js';
 import wildCardMatch from 'wildcard-match';
-import { isEqual } from 'radash';
+import { isEqual, sleep } from 'radash';
 import { NinetailedPlugin } from '@ninetailed/experience.js-plugin-analytics';
 
 declare global {
@@ -134,6 +134,8 @@ export class NinetailedPrivacyPlugin extends NinetailedPlugin {
     } else {
       this.instance.storage.removeItem(CONSENT);
     }
+    // There seems to be a race condition on the storage, so we need to wait a bit
+    await sleep(1);
     await this.enableFeatures(this.getConfig().enabledFeatures);
   }
 

--- a/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
+++ b/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
@@ -101,7 +101,6 @@ export class NinetailedPrivacyPlugin extends NinetailedPlugin {
   private _ready = false;
 
   private readonly config: PrivacyConfig;
-  // TODO not sure about the name of this variable
   private readonly acceptedConsentConfig: PrivacyConfig;
   private readonly queue: any[] = [];
 

--- a/packages/tests/generated-packages/src/lib/__snapshots__/generated-package-json.spec.ts.snap
+++ b/packages/tests/generated-packages/src/lib/__snapshots__/generated-package-json.spec.ts.snap
@@ -82,9 +82,9 @@ Object {
 exports[`Generated package.json files dist/packages/plugins/google-tagmanager/package.json should match the snapshot 1`] = `
 Object {
   "dependencies": Object {
-    "@ninetailed/experience.js": "7.5.2-beta.1",
+    "@ninetailed/experience.js": "*",
     "@ninetailed/experience.js-plugin-analytics": "*",
-    "@ninetailed/experience.js-shared": "7.5.2-beta.1",
+    "@ninetailed/experience.js-shared": "*",
     "tslib": "2.4.1",
   },
   "description": "Ninetailed SDK plugin for Google Tag Manager",
@@ -198,14 +198,17 @@ Object {
 exports[`Generated package.json files dist/packages/plugins/privacy/package.json should match the snapshot 1`] = `
 Object {
   "dependencies": Object {
-    "@ninetailed/experience.js": "7.5.2-beta.1",
+    "@ninetailed/experience.js": "*",
     "@ninetailed/experience.js-plugin-analytics": "*",
-    "@ninetailed/experience.js-shared": "7.5.2-beta.1",
+    "@ninetailed/experience.js-shared": "*",
     "radash": "10.9.0",
     "tslib": "2.4.1",
     "wildcard-match": "5.1.2",
   },
   "description": "Ninetailed SDK plugin for privacy",
+  "devDependencies": Object {
+    "analytics": "0.8.1",
+  },
   "keywords": Array [
     "privacy",
     "ninetailed",


### PR DESCRIPTION
### **User description**
This PR adds a second argument to the Privacy Plugin constructor. A privacy config which blocks events, removes traits and properties and also deactivates features, when the consent was given.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhanced `NinetailedPrivacyPlugin` to support configurations that apply after consent is given.
- Added comprehensive tests for various configurations and consent scenarios.
- Updated test environment to `jsdom` for better simulation of browser-like environments.
- Added `analytics` as a development dependency to support testing.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NinetailedPrivacyPlugin.spec.ts</strong><dd><code>Add comprehensive tests for NinetailedPrivacyPlugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/plugins/privacy/src/NinetailedPrivacyPlugin.spec.ts

<li>Added tests for <code>NinetailedPrivacyPlugin</code> to cover various <br>configurations and consent scenarios.<br> <li> Introduced <code>TestPlugin</code> class for mocking purposes.<br> <li> Implemented setup function for initializing test instances.<br> <li> Verified behavior for event interception and feature enabling based on <br>consent.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/49/files#diff-e4affbc0bc04ce341ae11ea540a352175fa89c421688dae07aebf5a2c5541a08">+173/-0</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NinetailedPrivacyPlugin.ts</strong><dd><code>Enhance NinetailedPrivacyPlugin with post-consent configurations</code></dd></summary>
<hr>
      
packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts

<li>Exported <code>PrivacyConfig</code> type and default configurations.<br> <li> Added <code>acceptedConsentConfig</code> to handle configurations post-consent.<br> <li> Modified methods to utilize <code>getConfig</code> for dynamic configuration based <br>on consent.<br> <li> Adjusted feature enabling logic to be based on consent status.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/49/files#diff-201595a7aff8e37424c48a5763e7f3287f4761fc8803470edea1485e4740c047">+56/-28</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jest.config.js</strong><dd><code>Update test environment to jsdom</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/plugins/privacy/jest.config.js

- Changed test environment from 'node' to 'jsdom'.



</details>
    

  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/49/files#diff-2ad1fe12df0ee87d32d612e36645ae1cc3d5f31279052b0edf2fed703d5962f1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add analytics as a development dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/plugins/privacy/package.json

- Added `analytics` as a development dependency.



</details>
    

  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/49/files#diff-90ce21978d84738d23c5ea8893be4bbd305ee9cd3087fc96c619ae4e8130b1c6">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

