### PR TITLE
DEV-3694 Add async custom variant mapper to Contentful Utility SDK

### DIFF
--- a/packages/utils/contentful/src/lib/ExperienceMapper.ts
+++ b/packages/utils/contentful/src/lib/ExperienceMapper.ts
@@ -65,6 +65,11 @@ export type MapVariantFunction<
   Out extends Reference
 > = (input: EntryLike<In>) => Out;
 
+export type MapVariantFunctionAsync<
+  In extends EntryFields,
+  Out extends Reference
+> = (input: EntryLike<In>) => Promise<Out>;
+
 export class ExperienceMapper {
   static isExperienceEntry<VariantFields extends EntryFields>(
     entry: ExperienceEntryLike<VariantFields>
@@ -93,6 +98,19 @@ export class ExperienceMapper {
   ) {
     const { sys, fields } = validateExperienceEntry(ctfEntry);
     const variants = fields.nt_variants.map(mapFn);
+    const experience = createExperience(sys.id, fields, variants);
+    return DefaultExperienceMapper.mapExperience(experience);
+  }
+
+  static async mapCustomExperienceAsync<
+    Variant extends Reference,
+    VariantFields extends EntryFields
+  >(
+    ctfEntry: ExperienceEntryLike<VariantFields>,
+    mapFn: MapVariantFunctionAsync<VariantFields, Variant>
+  ) {
+    const { sys, fields } = validateExperienceEntry(ctfEntry);
+    const variants = await Promise.all(fields.nt_variants.map(mapFn));
     const experience = createExperience(sys.id, fields, variants);
     return DefaultExperienceMapper.mapExperience(experience);
   }

--- a/packages/utils/contentful/src/lib/__test__/ExperienceMapper.spec.ts
+++ b/packages/utils/contentful/src/lib/__test__/ExperienceMapper.spec.ts
@@ -75,4 +75,29 @@ describe('Contentful Experience Mapper', () => {
       .filter(ExperienceMapper.isExperiment)
       .map((experience) => ExperienceMapper.mapExperience(experience));
   });
+
+  it('Should map experiences with custom mapping function for variants including an async step', async () => {
+    const mapped = await Promise.all(
+      EXPERIENCES.map((experience) =>
+        ExperienceMapper.mapCustomExperienceAsync(
+          experience,
+          async (variant) => {
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+            return {
+              id: variant.sys.id,
+              headline: variant.fields.entryTitle,
+              x: variant.fields.desktopImage,
+            };
+          }
+        )
+      )
+    );
+
+    mapped.forEach((mappedExperience) => {
+      expect(mappedExperience.description).not.toBeUndefined();
+      expect(mappedExperience.name).not.toBeUndefined();
+      expect(mappedExperience.audience?.description).not.toBeUndefined();
+      expect(mappedExperience.audience?.name).not.toBeUndefined();
+    });
+  });
 });

--- a/packages/utils/contentful/src/lib/__test__/ExperienceMapper.spec.ts
+++ b/packages/utils/contentful/src/lib/__test__/ExperienceMapper.spec.ts
@@ -86,7 +86,7 @@ describe('Contentful Experience Mapper', () => {
             return {
               id: variant.sys.id,
               headline: variant.fields.entryTitle,
-              x: variant.fields.desktopImage,
+              image: variant.fields.desktopImage,
             };
           }
         )
@@ -98,6 +98,16 @@ describe('Contentful Experience Mapper', () => {
       expect(mappedExperience.name).not.toBeUndefined();
       expect(mappedExperience.audience?.description).not.toBeUndefined();
       expect(mappedExperience.audience?.name).not.toBeUndefined();
+      mappedExperience.components.forEach((component) => {
+        component.variants.forEach((variant) => {
+          expect(variant.id).not.toBeUndefined();
+
+          if ('headline' in variant) {
+            expect(variant.headline).not.toBeUndefined();
+            expect(variant.image).not.toBeUndefined();
+          }
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
### **User description**
The Experience SDK currently only allows for synchronous mapping of variants in the mapCustomExperience  helper method of the Contentful utils SDK.

Some of the SDK users need to do async operations like resolving data from a different system in there already built out data normalization frameworks. They could not reuse their tooling as long as we don’t provide a async helper.

This PR adds a new function `mapCustomExperienceAsync`, which allows to run async operations in the Mapping step of the variant. 

E.g.:

```ts
 const mapped = await Promise.all(
      EXPERIENCES.map((experience) =>
        ExperienceMapper.mapCustomExperienceAsync(
          experience,
          async (variant) => {
            await new Promise((resolve) => setTimeout(resolve, 1000));
            return {
              id: variant.sys.id,
              headline: variant.fields.headline,
            };
          }
        )
      )
    );
```


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added a new type `MapVariantFunctionAsync` to support asynchronous mapping functions.
- Introduced a new static method `mapCustomExperienceAsync` in the `ExperienceMapper` class to allow async operations during the mapping step.
- Added a unit test to verify the functionality of the `mapCustomExperienceAsync` method, ensuring it correctly handles async operations in variant mapping.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ExperienceMapper.ts</strong><dd><code>Add asynchronous custom experience mapping functionality</code>&nbsp; </dd></summary>
<hr>
      
packages/utils/contentful/src/lib/ExperienceMapper.ts

<li>Added a new type <code>MapVariantFunctionAsync</code> for asynchronous mapping <br>functions.<br> <li> Introduced a new static method <code>mapCustomExperienceAsync</code> to handle <br>async operations in the mapping step.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/50/files#diff-b78d607250d05c8d944d40c0760d80c9148319eb3106516e5c005405710fa591">+18/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ExperienceMapper.spec.ts</strong><dd><code>Add unit test for asynchronous custom experience mapping</code>&nbsp; </dd></summary>
<hr>
      
packages/utils/contentful/src/lib/__test__/ExperienceMapper.spec.ts

<li>Added a new unit test for the <code>mapCustomExperienceAsync</code> method.<br> <li> Ensured the test covers async operations in the variant mapping <br>process.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/50/files#diff-c8bd2f747e8bc669b8891755ef85b8f564b983908aaedde16a1b33195f04a486">+35/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

