### PR TITLE
Replace package version env var in all projects

### DIFF
--- a/packages/plugins/preview/project.json
+++ b/packages/plugins/preview/project.json
@@ -13,7 +13,7 @@
         "project": "packages/plugins/preview/package.json",
         "entryFile": "packages/plugins/preview/src/index.ts",
         "external": [],
-        "rollupConfig": "@nx/react/plugins/bundle-rollup",
+        "rollupConfig": "packages/plugins/preview/rollup.config.cjs",
         "format": ["cjs", "esm"],
         "assets": [
           {

--- a/packages/plugins/preview/rollup.config.cjs
+++ b/packages/plugins/preview/rollup.config.cjs
@@ -1,0 +1,6 @@
+const nrwlConfig = require('@nx/react/plugins/bundle-rollup');
+const withPackageVersion = require('../../../withPackageVersion');
+
+module.exports = (config) => {
+  return withPackageVersion(nrwlConfig(config));
+};

--- a/packages/sdks/shared/rollup.config.cjs
+++ b/packages/sdks/shared/rollup.config.cjs
@@ -1,24 +1,6 @@
 const nrwlConfig = require('@nx/react/plugins/bundle-rollup');
-const replace = require('@rollup/plugin-replace');
-require('dotenv').config({ path: '../../../.env.local' });
+const withPackageVersion = require('../../../withPackageVersion');
 
 module.exports = (config) => {
-  if (!process.env.NX_PACKAGE_VERSION) {
-    throw new Error('NX_PACKAGE_VERSION is not set');
-  }
-
-  const nxConfig = nrwlConfig(config);
-  return {
-    ...nxConfig,
-    plugins: [
-      ...nxConfig.plugins,
-      replace({
-        "process.env['NX_PACKAGE_VERSION']": JSON.stringify(
-          process.env.NX_PACKAGE_VERSION
-        ),
-        delimiters: ['', ''],
-        preventAssignment: true,
-      }),
-    ],
-  };
+  return withPackageVersion(nrwlConfig(config));
 };

--- a/withPackageVersion.js
+++ b/withPackageVersion.js
@@ -1,0 +1,30 @@
+const path = require('path');
+const devkit = require('@nrwl/devkit');
+
+const replace = require('@rollup/plugin-replace');
+
+require('dotenv').config({
+  path: path.join(devkit.workspaceRoot, '.env.local'),
+});
+
+const withPackageVersion = (config) => {
+  if (!process.env.NX_PACKAGE_VERSION) {
+    throw new Error('NX_PACKAGE_VERSION is not set');
+  }
+
+  return {
+    ...config,
+    plugins: [
+      ...(config.plugins || []),
+      replace({
+        "process.env['NX_PACKAGE_VERSION']": JSON.stringify(
+          process.env.NX_PACKAGE_VERSION
+        ),
+        delimiters: ['', ''],
+        preventAssignment: true,
+      }),
+    ],
+  };
+};
+
+module.exports = withPackageVersion;


### PR DESCRIPTION
### **User description**
The env var `NX_PACKAGE_VERSION` was only replaced in the build step of the shared package.

This PR replaces it properly for the preview plugin


___

### **PR Type**
Enhancement


___

### **Description**
- Added a new utility function `withPackageVersion` to handle the replacement of the `NX_PACKAGE_VERSION` environment variable in Rollup configurations.
- Updated the Rollup configuration for the preview plugin to use a custom configuration file and integrated the `withPackageVersion` utility.
- Refactored the shared SDK Rollup configuration to use the new `withPackageVersion` utility, removing the inline logic for package version replacement.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>withPackageVersion.js</strong><dd><code>Add utility for package version replacement in Rollup config</code></dd></summary>
<hr>
      
withPackageVersion.js

<li>Created a new utility function <code>withPackageVersion</code> to handle package <br>version replacement.<br> <li> Utilizes <code>@rollup/plugin-replace</code> to replace <code>NX_PACKAGE_VERSION</code> <br>environment variable.<br> <li> Throws an error if <code>NX_PACKAGE_VERSION</code> is not set.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/52/files#diff-7bf54901f37359bce4b9439855c5aa3bd25784dfef3a345e77959ba8723b1c37">+30/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rollup.config.cjs</strong><dd><code>Add custom Rollup configuration for preview plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/plugins/preview/rollup.config.cjs

<li>Added custom Rollup configuration for the preview plugin.<br> <li> Integrated <code>withPackageVersion</code> utility.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/52/files#diff-e701a49e0cb2eb675083fe40ad5bd51f68d234b085365c764951264ab04514d1">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rollup.config.cjs</strong><dd><code>Refactor shared SDK Rollup config to use utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/sdks/shared/rollup.config.cjs

<li>Refactored to use <code>withPackageVersion</code> utility for package version <br>replacement.<br> <li> Removed inline package version replacement logic.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/52/files#diff-5150969c40e732c0761d8cec6805947b3040c448cb977d5fa7fbfbd300df98e5">+2/-20</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>project.json</strong><dd><code>Update Rollup config path for preview plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/plugins/preview/project.json

- Updated Rollup config path to use custom configuration.



</details>
    

  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/52/files#diff-585440d7f216cb2d3da4af0efbbcf680097d41b46dc6801961cb721050896e44">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

