### PR TITLE
Dev 3831 experience js experience mapper wont default a null or missing variants array correctly

### DIFF
--- a/packages/utils/contentful/src/types/ExperienceEntry.spec.ts
+++ b/packages/utils/contentful/src/types/ExperienceEntry.spec.ts
@@ -11,11 +11,44 @@ describe('ExperienceEntry', () => {
     ).toEqual([]);
   });
 
+  it('Should not accept a null value as variants', () => {
+    expect(
+      () =>
+        ExperienceEntry.parse({
+          sys: { id: 'experience' },
+          fields: {
+            ...experienceEntryWithoutVariants.fields,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-expect-error
+            nt_variants: null,
+          },
+        }).fields.nt_variants
+    ).toThrow();
+  });
+
   it('should parse an ExperienceEntry without linkType', () => {
     experienceEntryWithoutLinkType.map((entry) => {
       expect(
         ExperienceEntry.parse(entry as unknown as ExperienceEntryLike)
       ).toMatchSnapshot();
     });
+  });
+
+  it('Should not accept invalid variants', () => {
+    expect(() =>
+      ExperienceEntry.parse({
+        sys: { id: 'experience' },
+        fields: {
+          ...experienceEntryWithoutVariants.fields,
+          nt_variants: [
+            {
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-expect-error
+              key: 'invalid-variant',
+            },
+          ],
+        },
+      })
+    ).toThrow();
   });
 });

--- a/packages/utils/javascript/src/lib/ExperienceMapper.spec.ts
+++ b/packages/utils/javascript/src/lib/ExperienceMapper.spec.ts
@@ -83,4 +83,21 @@ describe('Experience Mapper', () => {
       { id: 'variant', hidden: true },
     ]);
   });
+
+  it('should preserve the type of the variants', () => {
+    const mapped = ExperienceMapper.mapExperience({
+      ...defaultExperience,
+      variants: [{ id: 'variant', foo: 'bar' }],
+    });
+
+    const variant = mapped.components[0].variants[0];
+    if (!('hidden' in variant)) {
+      // Yeay! It correctly inferred the type of the property "foo" on the variant
+      expect(variant.foo).toBe('bar');
+    }
+
+    expect(mapped.components[0].variants).toStrictEqual([
+      { id: 'variant', foo: 'bar' },
+    ]);
+  });
 });

--- a/packages/utils/javascript/src/types/Experiement.spec.ts
+++ b/packages/utils/javascript/src/types/Experiement.spec.ts
@@ -1,0 +1,43 @@
+import { Reference } from '@ninetailed/experience.js-shared';
+import { Experiment } from './Experiment';
+
+describe('Experiment Schema Validation', () => {
+  it('Should default missing variants to an empty array', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    const experiment = Experiment.parse({
+      id: 'experience-without-variants',
+      name: 'Experience without variants',
+      type: 'nt_experiment',
+    });
+
+    expect(experiment.variants).toEqual([]);
+  });
+
+  it('Should default null variants to an empty array', () => {
+    const experiment = Experiment.parse({
+      id: 'experience-with-null-variants',
+      name: 'Experience with null variants',
+      type: 'nt_experiment',
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      variants: null,
+    });
+
+    expect(experiment.variants).toEqual([]);
+  });
+
+  it('Should validate the variants array to contain only element with an id', () => {
+    const experiment = Experiment.parse({
+      id: 'experience-with-invalid-variants',
+      name: 'Experience with invalid variants',
+      type: 'nt_experiment',
+      variants: [
+        { id: 'valid-variant', foo: 'bar' },
+        { key: 'invalid-variant' } as unknown as Reference,
+      ],
+    });
+
+    expect(experiment.variants).toEqual([{ id: 'valid-variant', foo: 'bar' }]);
+  });
+});

--- a/packages/utils/javascript/src/types/Experience.spec.ts
+++ b/packages/utils/javascript/src/types/Experience.spec.ts
@@ -1,0 +1,28 @@
+import { Experience } from './Experience';
+
+describe('Experience Schema Validation', () => {
+  it('Should default missing variants to an empty array', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    const experience = Experience.parse({
+      id: 'experience-without-variants',
+      name: 'Experience without variants',
+      type: 'nt_experiment',
+    });
+
+    expect(experience.variants).toEqual([]);
+  });
+
+  it('Should default null variants to an empty array', () => {
+    const experience = Experience.parse({
+      id: 'experience-with-null-variants',
+      name: 'Experience with null variants',
+      type: 'nt_experiment',
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      variants: null,
+    });
+
+    expect(experience.variants).toEqual([]);
+  });
+});

--- a/packages/utils/javascript/src/types/Experience.spec.ts
+++ b/packages/utils/javascript/src/types/Experience.spec.ts
@@ -1,3 +1,4 @@
+import { Reference } from '@ninetailed/experience.js-shared';
 import { Experience } from './Experience';
 
 describe('Experience Schema Validation', () => {
@@ -24,5 +25,19 @@ describe('Experience Schema Validation', () => {
     });
 
     expect(experience.variants).toEqual([]);
+  });
+
+  it('Should validate the variants array to contain only element with an id', () => {
+    const experience = Experience.parse({
+      id: 'experience-with-invalid-variants',
+      name: 'Experience with invalid variants',
+      type: 'nt_experiment',
+      variants: [
+        { id: 'valid-variant', foo: 'bar' },
+        { key: 'invalid-variant' } as unknown as Reference,
+      ],
+    });
+
+    expect(experience.variants).toEqual([{ id: 'valid-variant', foo: 'bar' }]);
   });
 });

--- a/packages/utils/javascript/src/types/Experience.ts
+++ b/packages/utils/javascript/src/types/Experience.ts
@@ -64,7 +64,7 @@ const parse = <T extends Reference>(
 
   return {
     ...output,
-    variants: input.variants || [],
+    variants: output.variants as T[],
   };
 };
 
@@ -79,7 +79,7 @@ const safeParse = <T extends Reference>(input: ExperienceLike<T>) => {
     ...output,
     data: {
       ...output.data,
-      variants: input.variants || [],
+      variants: output.data.variants as T[],
     },
   };
 };

--- a/packages/utils/javascript/src/types/Experience.ts
+++ b/packages/utils/javascript/src/types/Experience.ts
@@ -64,7 +64,7 @@ const parse = <T extends Reference>(
 
   return {
     ...output,
-    variants: input.variants,
+    variants: input.variants || [],
   };
 };
 
@@ -79,7 +79,7 @@ const safeParse = <T extends Reference>(input: ExperienceLike<T>) => {
     ...output,
     data: {
       ...output.data,
-      variants: input.variants,
+      variants: input.variants || [],
     },
   };
 };

--- a/packages/utils/javascript/src/types/Experiment.ts
+++ b/packages/utils/javascript/src/types/Experiment.ts
@@ -30,7 +30,7 @@ const parse = <T extends Reference>(
 
   return {
     ...output,
-    variants: input.variants,
+    variants: output.variants as T[],
   };
 };
 
@@ -45,7 +45,7 @@ const safeParse = <T extends Reference>(input: ExperimentLike<T>) => {
     ...output,
     data: {
       ...output.data,
-      variants: input.variants,
+      variants: output.data.variants as T[],
     },
   };
 };


### PR DESCRIPTION
### **User description**
This PR fixes a bug which made it possible to put `variants` as `null` or `undefined` into the `isExperienceEntry` as valid object. As the `variants` didn't get defaulted to an empty array, the `ExperienceMapper.mapExperience` function failed.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added tests to ensure `null` and invalid variants are not accepted in `ExperienceEntry`.
- Added tests to default missing or null variants to an empty array in `Experiment` and `Experience`.
- Added test to ensure the type of variants is preserved in `ExperienceMapper`.
- Fixed the `parse` and `safeParse` functions in `Experience` and `Experiment` to correctly handle variants.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ExperienceEntry.spec.ts</strong><dd><code>Add tests for invalid and null variants in ExperienceEntry</code></dd></summary>
<hr>
      
packages/utils/contentful/src/types/ExperienceEntry.spec.ts

<li>Added tests to ensure <code>null</code> and invalid variants are not accepted.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/54/files#diff-1e5cc3f8c6b4693d5e3b9f5e7cb838154cdb18f516a1c0cb87ed430c9d238bb1">+33/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ExperienceMapper.spec.ts</strong><dd><code>Add test to preserve variant types in ExperienceMapper</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/utils/javascript/src/lib/ExperienceMapper.spec.ts

- Added test to ensure the type of variants is preserved.



</details>
    

  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/54/files#diff-5d0e71dbf2a658c5a10feccfb9ff654088ec4cf81b790237d48bccede183f08a">+17/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Experiement.spec.ts</strong><dd><code>Add tests for defaulting and validating variants in Experiment</code></dd></summary>
<hr>
      
packages/utils/javascript/src/types/Experiement.spec.ts

<li>Added tests to default missing or null variants to an empty array.<br> <li> Added test to validate the variants array.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/54/files#diff-4582c893eaa37e6cb6782f9ca86372b81ebc8d91b2d6754abd91304a6ab48372">+43/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Experience.spec.ts</strong><dd><code>Add tests for defaulting and validating variants in Experience</code></dd></summary>
<hr>
      
packages/utils/javascript/src/types/Experience.spec.ts

<li>Added tests to default missing or null variants to an empty array.<br> <li> Added test to validate the variants array.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/54/files#diff-54867b4555d3b0cd0fe36196aa72b38870516a993354a2adffe12b5b42837d12">+43/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Experience.ts</strong><dd><code>Fix variant handling in Experience parse functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/utils/javascript/src/types/Experience.ts

<li>Fixed the <code>parse</code> and <code>safeParse</code> functions to correctly handle variants.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/54/files#diff-68744a63e99d245d789fa56b60fa9e8fbe7362bc514fab4b622d6f273948eb90">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Experiment.ts</strong><dd><code>Fix variant handling in Experiment parse functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/utils/javascript/src/types/Experiment.ts

<li>Fixed the <code>parse</code> and <code>safeParse</code> functions to correctly handle variants.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/54/files#diff-cbfa6302d1a0e5091703d47b9d0a7c91b5aba4d7442f40b46ea44b0c2213993c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

