### PR TITLE
Dev 4016 Handle the building of events in InsightsPlugin through EventBuilder

### DIFF
--- a/packages/plugins/insights/package.json
+++ b/packages/plugins/insights/package.json
@@ -19,7 +19,6 @@
     "@ninetailed/experience.js": "*",
     "@ninetailed/experience.js-shared": "*",
     "@ninetailed/experience.js-plugin-analytics": "*",
-    "uuid": "9.0.0",
     "async-retry": "1.3.3",
     "radash": "10.9.0"
   },

--- a/packages/plugins/insights/package.json
+++ b/packages/plugins/insights/package.json
@@ -2,7 +2,7 @@
   "name": "@ninetailed/experience.js-plugin-insights",
   "version": "7.6.0-beta.1",
   "type": "commonjs",
-  "description": "Ninetailed SDK plugin for Adobe Analytics",
+  "description": "Ninetailed SDK plugin for Ninetailed Insights",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.ts
@@ -18,7 +18,10 @@ import {
   logger,
   type ComponentViewEvent,
 } from '@ninetailed/experience.js-shared';
-import type { EventBuilder } from '@ninetailed/experience.js';
+import type {
+  EventBuilder,
+  RequiresEventBuilder,
+} from '@ninetailed/experience.js';
 
 import type { ComponentViewEventBatch } from './types/Event/ComponentViewEventBatch';
 import { NinetailedInsightsApiClient } from './api/NinetailedInsightsApiClient';
@@ -36,7 +39,8 @@ export class NinetailedInsightsPlugin
     InterestedInSeenElements,
     InterestedInProfileChange,
     InterestedInHiddenPage,
-    AcceptsCredentials
+    AcceptsCredentials,
+    RequiresEventBuilder
 {
   public override name = 'ninetailed:insights';
 
@@ -200,7 +204,7 @@ export class NinetailedInsightsPlugin
     this.eventsQueue = [];
   }
 
-  setCredentials(credentials: Credentials) {
+  public setCredentials(credentials: Credentials) {
     this.insightsApiClient = new NinetailedInsightsApiClient({
       url: this.insightsApiClientUrl,
       clientId: credentials.clientId,
@@ -208,7 +212,7 @@ export class NinetailedInsightsPlugin
     });
   }
 
-  public injectEventBuilder(eventBuilder: EventBuilder) {
+  public setEventBuilder(eventBuilder: EventBuilder) {
     this.eventBuilder = eventBuilder;
   }
 }

--- a/packages/sdks/javascript/src/index.ts
+++ b/packages/sdks/javascript/src/index.ts
@@ -7,6 +7,7 @@ export * from './lib/experience';
 
 export * from './lib/plugins/selectPluginsHavingExperienceSelectionMiddleware';
 export * from './lib/plugins/selectPluginsHavingOnChangeEmitter';
+export * from './lib/types/interfaces/RequiresEventBuilder';
 export * from './lib/types/interfaces/HasExperienceSelectionMiddleware';
 export * from './lib/types/interfaces/InterestedInSeenElements';
 export * from './lib/types/interfaces/InterestedInProfileChange';

--- a/packages/sdks/javascript/src/index.ts
+++ b/packages/sdks/javascript/src/index.ts
@@ -13,5 +13,6 @@ export * from './lib/types/interfaces/InterestedInProfileChange';
 export * from './lib/types/interfaces/InterestedInHiddenPage';
 export * from './lib/types/interfaces/AcceptsCredentials';
 export * from './lib/utils/OnChangeEmitter';
+export * from './lib/utils/EventBuilder';
 
 export type { Profile } from '@ninetailed/experience.js-shared';

--- a/packages/sdks/javascript/src/lib/Ninetailed.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.ts
@@ -63,6 +63,7 @@ import {
   hasComponentViewTrackingThreshold,
 } from '@ninetailed/experience.js-plugin-analytics';
 import { EventBuilder } from './utils/EventBuilder';
+import { requiresEventBuilder } from './guards/requiresEventBuilder';
 
 declare global {
   interface Window {
@@ -207,6 +208,8 @@ export class Ninetailed implements NinetailedInstance {
 
     this.plugins = (plugins ?? []).flat();
 
+    this.eventBuilder = new EventBuilder(buildClientContext);
+
     this.plugins.forEach((plugin) => {
       if (acceptsCredentials(plugin) && this.clientId && this.environment) {
         plugin.setCredentials({
@@ -220,6 +223,10 @@ export class Ninetailed implements NinetailedInstance {
           componentViewTrackingThreshold
         );
       }
+
+      if (requiresEventBuilder(plugin)) {
+        plugin.setEventBuilder(this.eventBuilder);
+      }
     });
 
     this._profileState = {
@@ -229,8 +236,6 @@ export class Ninetailed implements NinetailedInstance {
       error: null,
       from: 'api',
     };
-
-    this.eventBuilder = new EventBuilder(buildClientContext);
 
     this.ninetailedCorePlugin = new NinetailedCorePlugin({
       apiClient: this.apiClient,

--- a/packages/sdks/javascript/src/lib/guards/requiresEventBuilder.ts
+++ b/packages/sdks/javascript/src/lib/guards/requiresEventBuilder.ts
@@ -1,0 +1,12 @@
+import { RequiresEventBuilder } from '../types/interfaces/RequiresEventBuilder';
+
+export const requiresEventBuilder = (
+  plugin: unknown
+): plugin is RequiresEventBuilder => {
+  return (
+    typeof plugin === 'object' &&
+    plugin !== null &&
+    'setEventBuilder' in plugin &&
+    typeof plugin.setEventBuilder === 'function'
+  );
+};

--- a/packages/sdks/javascript/src/lib/types/interfaces/RequiresEventBuilder.ts
+++ b/packages/sdks/javascript/src/lib/types/interfaces/RequiresEventBuilder.ts
@@ -1,0 +1,5 @@
+import { EventBuilder } from '../../utils/EventBuilder';
+
+export interface RequiresEventBuilder {
+  setEventBuilder(eventBuilder: EventBuilder): void;
+}

--- a/packages/tests/generated-packages/src/lib/__snapshots__/generated-package-json.spec.ts.snap
+++ b/packages/tests/generated-packages/src/lib/__snapshots__/generated-package-json.spec.ts.snap
@@ -116,9 +116,8 @@ Object {
     "@ninetailed/experience.js-shared": "*",
     "async-retry": "1.3.3",
     "radash": "10.9.0",
-    "uuid": "9.0.0",
   },
-  "description": "Ninetailed SDK plugin for Adobe Analytics",
+  "description": "Ninetailed SDK plugin for Ninetailed Insights",
   "devDependencies": Object {
     "@jest/globals": "29.7.0",
   },


### PR DESCRIPTION
### **PR Type**
Enhancement, Dependencies


___

### **Description**
- Refactored the `NinetailedInsightsPlugin` to use the `EventBuilder` interface for building events.
- Implemented the `RequiresEventBuilder` interface and added error handling for missing `EventBuilder`.
- Exported `RequiresEventBuilder` interface and `EventBuilder` utility in the SDK.
- Added a guard to check if a plugin requires an `EventBuilder` and injected it accordingly.
- Removed the `uuid` dependency from the `insights` package.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NinetailedInsightsPlugin.ts</strong><dd><code>Refactor event building to use EventBuilder interface</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/plugins/insights/src/lib/NinetailedInsightsPlugin.ts

<li>Removed <code>uuid</code> dependency and related code.<br> <li> Introduced <code>EventBuilder</code> for building events.<br> <li> Added <code>RequiresEventBuilder</code> interface implementation.<br> <li> Added error handling for missing <code>EventBuilder</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/56/files#diff-304e153382cbfb9e86f4161304c73fe719ccb124ffe11412eb82590fbdc230cb">+25/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export EventBuilder and RequiresEventBuilder interfaces</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/sdks/javascript/src/index.ts

<li>Exported <code>RequiresEventBuilder</code> interface.<br> <li> Exported <code>EventBuilder</code> utility.<br>


</details>


  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/56/files#diff-809e66e8cb0727bac780659bd4302616442d7c1df9068dc86f76614aee71a1b1">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Ninetailed.ts</strong><dd><code>Inject EventBuilder into relevant plugins</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/sdks/javascript/src/lib/Ninetailed.ts

<li>Added <code>requiresEventBuilder</code> guard.<br> <li> Injected <code>EventBuilder</code> into plugins requiring it.<br>


</details>


  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/56/files#diff-ea69e52b9f3b0bb26cfdfa1539611fdf218037bf8db7dc0dd86461e18557dcce">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>requiresEventBuilder.ts</strong><dd><code>Add guard for RequiresEventBuilder interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/sdks/javascript/src/lib/guards/requiresEventBuilder.ts

- Added guard to check if a plugin requires an `EventBuilder`.



</details>


  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/56/files#diff-c044ba11a17d1333fa9f5c47793d7fd0ff8cb518b911d885917873f3a35c2261">+12/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>RequiresEventBuilder.ts</strong><dd><code>Define RequiresEventBuilder interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/sdks/javascript/src/lib/types/interfaces/RequiresEventBuilder.ts

- Defined `RequiresEventBuilder` interface.



</details>


  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/56/files#diff-695df15e9ba50aa08a49b7674d8e6dd79227e8daed4c0d30807680aceb033669">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Remove uuid dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/plugins/insights/package.json

- Removed `uuid` dependency.



</details>


  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/56/files#diff-a7aa604dacb7aec6c0a3997c72546203dd7f05453cffbe724964e0e9b605505b">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

