### PR TITLE
feat: Limit preview plugin to one instance

### DIFF
--- a/packages/plugins/preview/src/lib/plugin/WidgetContainer.ts
+++ b/packages/plugins/preview/src/lib/plugin/WidgetContainer.ts
@@ -16,10 +16,12 @@ type WidgetContainerOptions = {
 };
 
 export class WidgetContainer {
+  private static CONTAINER_CLASS = 'nt-preview-widget-container';
   private container: HTMLDivElement;
 
   constructor(private readonly options: WidgetContainerOptions) {
     this.container = document.createElement('div');
+    this.container.classList.add(WidgetContainer.CONTAINER_CLASS);
     this.container.style.position = 'fixed';
     this.container.style.zIndex = '999999';
     this.container.style.right = '0px';
@@ -58,5 +60,11 @@ export class WidgetContainer {
 
   public get element() {
     return this.container;
+  }
+
+  public static isContainerAttached() {
+    return (
+      document.querySelector(`.${WidgetContainer.CONTAINER_CLASS}`) !== null
+    );
   }
 }

--- a/packages/sdks/javascript/src/lib/experience/makeExperienceSelectMiddleware.ts
+++ b/packages/sdks/javascript/src/lib/experience/makeExperienceSelectMiddleware.ts
@@ -65,9 +65,16 @@ export const makeExperienceSelectMiddleware = <
         plugins
       );
 
-    const middlewareFunctions = pluginsWithMiddleware.map((plugin) =>
-      plugin.getExperienceSelectionMiddleware({ experiences, baseline })
-    );
+    const middlewareFunctions = pluginsWithMiddleware
+      .map((plugin) =>
+        plugin.getExperienceSelectionMiddleware({ experiences, baseline })
+      )
+      .filter(
+        (
+          result
+        ): result is ExperienceSelectionMiddleware<TBaseline, TVariant> =>
+          typeof result !== 'undefined'
+      );
 
     return pipe(...middlewareFunctions);
   };

--- a/packages/sdks/javascript/src/lib/types/interfaces/HasExperienceSelectionMiddleware.ts
+++ b/packages/sdks/javascript/src/lib/types/interfaces/HasExperienceSelectionMiddleware.ts
@@ -30,7 +30,7 @@ export type BuildExperienceSelectionMiddleware<
   TVariant extends Reference
 > = (
   arg: BuildExperienceSelectionMiddlewareArg<TVariant>
-) => ExperienceSelectionMiddleware<TBaseline, TVariant>;
+) => ExperienceSelectionMiddleware<TBaseline, TVariant> | undefined;
 
 export interface HasExperienceSelectionMiddleware<
   TBaseline extends Reference,


### PR DESCRIPTION
- All preview plugin instances that are not marked as active won't render anything to the DOM and won't listen to any events.  This ensures that at any given time only one instance is active. 
- This change requires a change to the `ExperienceSelectionMiddleware` type by allowing an `undefined` return type because we only want the active preview plugin to return a middleware function. 