### PR TITLE
Dev 4259 Use sticky flag from Experience API instead of expericen configuration entry

### DIFF
--- a/packages/sdks/javascript/src/lib/Ninetailed.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.ts
@@ -751,7 +751,15 @@ export class Ninetailed implements NinetailedInstance {
         return;
       }
 
-      const baselineVariants = selectBaselineWithVariants(experience, baseline);
+      const experienceWithStickyFromExperienceApi = {
+        ...experience,
+        sticky: selectedExperience.sticky,
+      };
+
+      const baselineVariants = selectBaselineWithVariants(
+        experienceWithStickyFromExperienceApi,
+        baseline
+      );
       if (!baselineVariants) {
         setSelectedVariant(
           overrideResult({
@@ -785,7 +793,7 @@ export class Ninetailed implements NinetailedInstance {
           status: 'success',
           loading: false,
           error: null,
-          experience,
+          experience: experienceWithStickyFromExperienceApi,
           variant,
           variantIndex: selectedExperience.variantIndex,
           audience: experience.audience ? experience.audience : null,

--- a/packages/sdks/shared/src/lib/types/SelectedVariantInfo/SelectedVariantInfo.ts
+++ b/packages/sdks/shared/src/lib/types/SelectedVariantInfo/SelectedVariantInfo.ts
@@ -4,6 +4,7 @@ export const SelectedVariantInfo = z.object({
   experienceId: z.string(),
   variantIndex: z.number(),
   variants: z.record(z.string()),
+  sticky: z.boolean().optional().default(false),
 });
 
 export type SelectedVariantInfo = z.infer<typeof SelectedVariantInfo>;


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Overwrite the sticky flag in the `experience` object with information from the experience API.
- Update the `SelectedVariantInfo` schema to include a `sticky` property with a default value of `false`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Ninetailed.ts</strong><dd><code>Overwrite sticky flag with experience API information</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/sdks/javascript/src/lib/Ninetailed.ts

<li>Added logic to overwrite the sticky flag with information from the <br>experience API.<br> <li> Modified the <code>experience</code> object to include the sticky flag from the <br>selected experience.<br> <li> Updated the <code>baselineVariants</code> and <code>setSelectedVariant</code> calls to use the <br>modified <code>experience</code> object.<br>


</details>


  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/60/files#diff-ea69e52b9f3b0bb26cfdfa1539611fdf218037bf8db7dc0dd86461e18557dcce">+10/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SelectedVariantInfo.ts</strong><dd><code>Add sticky flag to SelectedVariantInfo schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/sdks/shared/src/lib/types/SelectedVariantInfo/SelectedVariantInfo.ts

<li>Added <code>sticky</code> property to <code>SelectedVariantInfo</code> schema.<br> <li> Set default value of <code>sticky</code> property to <code>false</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/60/files#diff-27f987c7558c4f77ddb697b18b7fc08a887e03e6c43136baf4adca41c54874f7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

