### PR TITLE
chore: export type ComponentViewEventBatch from plugin-insights

### DIFF
--- a/packages/plugins/insights/src/index.ts
+++ b/packages/plugins/insights/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/NinetailedInsightsPlugin';
 export { NinetailedInsightsApiClient } from './lib/api/NinetailedInsightsApiClient';
 export { NinetailedInsightsPlugin as default } from './lib/NinetailedInsightsPlugin';
+export { type ComponentViewEventBatch } from './lib/types/Event/ComponentViewEventBatch';


### PR DESCRIPTION
We need this type to use `sendEventBatches()`