### PR TITLE
Dev 4362 Break through loading state, even if privacy plugin blocks events

### DIFF
--- a/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
+++ b/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
@@ -111,7 +111,6 @@ export class NinetailedPrivacyPlugin extends NinetailedPlugin {
 
   private readonly config: PrivacyConfig;
   private readonly acceptedConsentConfig: PrivacyConfig;
-  private readonly queue: any[] = [];
 
   constructor(
     config?: Partial<PrivacyConfig>,
@@ -256,8 +255,6 @@ export class NinetailedPrivacyPlugin extends NinetailedPlugin {
     ) =>
     ({ payload, abort }: { payload: any; abort: any }) => {
       if (!this.getConfig().allowedEvents.includes(eventType)) {
-        this.queue.push(payload);
-
         this.notifyOnRejectedEvent();
 
         return abort();
@@ -295,8 +292,6 @@ export class NinetailedPrivacyPlugin extends NinetailedPlugin {
         logger.info(
           '[Ninetailed Privacy Plugin] The track event was blocked, as it is not allowed to send by your configuration.'
         );
-
-        this.queue.push(payload);
 
         this.notifyOnRejectedEvent();
 

--- a/packages/sdks/javascript/src/lib/utils/EventBuilder.ts
+++ b/packages/sdks/javascript/src/lib/utils/EventBuilder.ts
@@ -26,8 +26,8 @@ export class EventBuilder {
   ) {
     return buildPageEvent({
       messageId: data?.messageId || uuid(),
-      ...data,
       timestamp: Date.now(),
+      ...data,
       properties: properties || {},
       ctx: this.buildRequestContext(),
     });


### PR DESCRIPTION
When the Ninetailed Privacy Plugin is configured to block any event, the loading state of the Ninetailed Provider will never get set to true.
The Default Loading Component in React works around this problem, by falling back to the baseline after a certain time.

This PR sends a `PROFILE_CHANGE` event, when the request got blocked with the cached fallback profile state or a error state, if no cached fallback is available.

The PR is currently in draft as we should discuss the implementation and maybe go for a bigger change and create new states of the profile in the SDK.