### PR TITLE
fix: stop abort errors from bubbling up for insights API calls

### DIFF
--- a/packages/plugins/insights/src/lib/api/NinetailedInsightsApiClient.ts
+++ b/packages/plugins/insights/src/lib/api/NinetailedInsightsApiClient.ts
@@ -186,7 +186,11 @@ export class NinetailedInsightsApiClient {
       logger.debug(`${requestName} request succesfully completed.`);
     } catch (error) {
       this.logRequestError(error, { requestName });
-      throw error;
+
+      // Abort errors caused by timeouts should not bubble up and be reported by third-party tools (e.g. Sentry)
+      if (!(error instanceof Error) || error.name !== 'AbortError') {
+        throw error;
+      }
     }
   }
 


### PR DESCRIPTION
Aborting API calls in the [fetchTimeout](https://github.com/ninetailed-inc/experience.js/blob/fa81270d2a7133fcb9888f36c46abbfa4faa3b7b/packages/sdks/shared/src/lib/api/fetch-timeout.ts#L23)  utility function throws an `AbortError` exception. This exception shouldn't be thrown all the way up to caller  and reach external error reporting tools such as Sentry. 

This PR stops the propagation of this exception when sending insights events batches. 