### PR TITLE
fix: send component view events only when a profile exists

### DIFF
--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.ts
@@ -152,9 +152,11 @@ export class NinetailedInsightsPlugin
 
     const previousProfile = this.profile ?? profile;
 
-    this.createEventsBatch(previousProfile);
+    if (previousProfile) {
+      this.createEventsBatch(previousProfile);
+    }
 
-    this.profile = profile;
+    this.profile = profile ?? undefined;
 
     this.seenElements = new WeakMap<Element, ElementSeenPayload[]>();
   };

--- a/packages/plugins/preview/src/lib/plugin/NinetailedPreviewPlugin.ts
+++ b/packages/plugins/preview/src/lib/plugin/NinetailedPreviewPlugin.ts
@@ -12,12 +12,17 @@ import {
   HasExperienceSelectionMiddleware,
   OnChangeEmitter,
   BuildExperienceSelectionMiddleware,
+  type ProfileChangedPayload,
+  type InterestedInProfileChange,
 } from '@ninetailed/experience.js';
 import type {
   PreviewPluginApi,
   ExposedAudienceDefinition,
 } from '@ninetailed/experience.js-preview-bridge';
-import { NinetailedPlugin } from '@ninetailed/experience.js-plugin-analytics';
+import {
+  type EventHandler,
+  NinetailedPlugin,
+} from '@ninetailed/experience.js-plugin-analytics';
 
 import { WidgetContainer } from './WidgetContainer';
 
@@ -43,7 +48,9 @@ type NinetailedPreviewPluginOptions = {
 
 export class NinetailedPreviewPlugin
   extends NinetailedPlugin
-  implements HasExperienceSelectionMiddleware<Reference, Reference>
+  implements
+    HasExperienceSelectionMiddleware<Reference, Reference>,
+    InterestedInProfileChange
 {
   public name = 'ninetailed:preview' + Math.random();
 
@@ -113,7 +120,9 @@ export class NinetailedPreviewPlugin
 
   public loaded = () => true;
 
-  public [PROFILE_CHANGE] = ({ payload }: { payload: any }) => {
+  public [PROFILE_CHANGE]: EventHandler<ProfileChangedPayload> = ({
+    payload,
+  }) => {
     if (!this.isActiveInstance) {
       return;
     }

--- a/packages/plugins/ssr/src/lib/analytics/plugin.ts
+++ b/packages/plugins/ssr/src/lib/analytics/plugin.ts
@@ -2,12 +2,15 @@ import Cookies from 'js-cookie';
 import {
   ANONYMOUS_ID,
   NINETAILED_ANONYMOUS_ID_COOKIE,
-  Profile,
   PROFILE_CHANGE,
   PROFILE_RESET,
 } from '@ninetailed/experience.js-shared';
 
-import { AnalyticsInstance } from '@ninetailed/experience.js';
+import {
+  AnalyticsInstance,
+  type ProfileChangedPayload,
+  type InterestedInProfileChange,
+} from '@ninetailed/experience.js';
 import {
   EventHandler,
   NinetailedPlugin,
@@ -23,7 +26,10 @@ type NinetailedSsrPluginOptions = {
   };
 };
 
-export class NinetailedSsrPlugin extends NinetailedPlugin {
+export class NinetailedSsrPlugin
+  extends NinetailedPlugin
+  implements InterestedInProfileChange
+{
   public name = 'ninetailed:ssr';
 
   private cookieDomain?: string;
@@ -44,7 +50,7 @@ export class NinetailedSsrPlugin extends NinetailedPlugin {
     }
   };
 
-  public [PROFILE_CHANGE]: EventHandler<{ profile?: Profile }> = ({
+  public [PROFILE_CHANGE]: EventHandler<ProfileChangedPayload> = ({
     payload,
   }) => {
     if (payload.profile) {

--- a/packages/sdks/javascript/src/lib/types/ProfileChangedPayload.ts
+++ b/packages/sdks/javascript/src/lib/types/ProfileChangedPayload.ts
@@ -1,5 +1,5 @@
 import { type Profile } from '@ninetailed/experience.js-shared';
 
 export type ProfileChangedPayload = {
-  profile: Profile;
+  profile: Profile | null;
 };


### PR DESCRIPTION
[DEV-4470](https://contentful.atlassian.net/browse/DEV-4470)

The `NinetailedCorePlugin` can dispatch the `PROFILE_CHANGE` event with a null profile. This was not reflected in the type of the event payload, and therefore some component seen events were being sent with a null profile, causing validation errors on the backend. 

[DEV-4470]: https://contentful.atlassian.net/browse/DEV-4470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ