### PR TITLE
fix: avoid circular references when stringifying json

### DIFF
--- a/packages/sdks/react/src/lib/Experience/useExperience.spec.tsx
+++ b/packages/sdks/react/src/lib/Experience/useExperience.spec.tsx
@@ -180,4 +180,77 @@ describe('useExperience', () => {
     expect(result.current.experience).toEqual(experience);
     expect(result.current.audience).toEqual(experience.audience);
   });
+
+  it('handles circular references in an object', async () => {
+    const ninetailed = mockNinetailed();
+
+    const experience = {
+      id: '3m1HTWSCdvCHz3qXDaqkOm',
+      type: 'nt_experiment' as const,
+      audience: {
+        id: '5A1ZvBh2chTzPnlD3N38V2',
+      },
+      distribution: [
+        {
+          index: 0,
+          start: 0,
+          end: 1,
+        },
+      ],
+      trafficAllocation: 1,
+      components: [
+        {
+          baseline: {
+            id: '3HQIlpV2OtnpSbs2zRwDGi',
+          },
+          variants: [
+            {
+              id: '6ytJPD38eqprLooUR0ms1q',
+            },
+            {
+              id: 'Z51sGdeBlUIVDqpbzF90H',
+            },
+            {
+              id: '642elZ1sAlE0F2WloYv3Jk',
+            },
+          ],
+        },
+      ],
+    };
+
+    const baseline = {
+      id: '3HQIlpV2OtnpSbs2zRwDGi',
+    };
+
+    // This is not necssarily a real life example, but it's a good way to test circular references
+    (experience as any).exp = experience;
+
+    const { result } = renderHook(
+      () =>
+        useExperience({
+          baseline,
+          experiences: [experience],
+        }),
+      {
+        wrapper: createNinetailedContextWrapper(ninetailed),
+      }
+    );
+
+    await sleep(5);
+
+    await act(async () => {
+      ninetailed.identify('test');
+    });
+
+    expect(result.current.status).toEqual('success');
+    expect(result.current.loading).toEqual(false);
+    expect(result.current.variantIndex).toEqual(1);
+    expect(result.current.variant).toEqual(
+      experience.components[0].variants[0]
+    );
+    expect(result.current.baseline).toEqual(experience.components[0].baseline);
+    expect(result.current.hasVariants).toEqual(true);
+    expect(result.current.experience).toEqual(experience);
+    expect(result.current.audience).toEqual(experience.audience);
+  });
 });

--- a/packages/sdks/react/src/lib/Experience/useExperience.ts
+++ b/packages/sdks/react/src/lib/Experience/useExperience.ts
@@ -5,6 +5,7 @@ import {
   Reference,
   VariantRef,
 } from '@ninetailed/experience.js';
+import { circularJsonStringify } from '@ninetailed/experience.js-shared';
 
 import { useNinetailed } from '../useNinetailed';
 import { useEffect, useState } from 'react';
@@ -103,7 +104,7 @@ export const useExperience = <
     return ninetailed.onSelectVariant({ baseline, experiences }, (state) => {
       setExperience(state as UseExperienceReturn<TBaseline, TVariant>);
     });
-  }, [JSON.stringify(baseline), JSON.stringify(experiences)]);
+  }, [circularJsonStringify(baseline), circularJsonStringify(experiences)]);
 
   return experience;
 };

--- a/packages/sdks/shared/src/index.ts
+++ b/packages/sdks/shared/src/index.ts
@@ -83,6 +83,7 @@ export * from './lib/utils/unionBy';
 export * from './lib/utils/pickBy';
 export * from './lib/utils/template';
 export * from './lib/utils/events';
+export * from './lib/utils/circularJsonStringify/circularJsonStringify';
 
 // experience selection helpers
 export * from './lib/utils/experiences/constants';

--- a/packages/sdks/shared/src/lib/utils/circularJsonStringify/circularJsonStringify.spec.ts
+++ b/packages/sdks/shared/src/lib/utils/circularJsonStringify/circularJsonStringify.spec.ts
@@ -1,0 +1,116 @@
+import { circularJsonStringify } from './circularJsonStringify';
+
+type Comment = {
+  id: string;
+  text: string;
+  parent?: Comment;
+  users?: User[];
+};
+
+type User = {
+  id: string;
+};
+
+describe('circularJsonStringify', () => {
+  it('should return a stringified object', () => {
+    const comment: Comment = { id: '1', text: 'foo' };
+
+    const result = circularJsonStringify(comment);
+    expect(result).toEqual('{"id":"1","text":"foo"}');
+  });
+
+  it('should return a stringified object with nested objects', () => {
+    const comment: Comment = {
+      id: '1',
+      text: 'foo',
+      users: [
+        {
+          id: 'u1',
+        },
+      ],
+    };
+
+    const result = circularJsonStringify(comment);
+
+    expect(result).toEqual('{"id":"1","text":"foo","users":[{"id":"u1"}]}');
+  });
+
+  it('should return a stringified array', () => {
+    const comment1 = { id: '1', text: 'foo' };
+    const comment2 = { id: '2', text: 'bar' };
+
+    const result = circularJsonStringify([comment1, comment2]);
+    expect(result).toEqual('[{"id":"1","text":"foo"},{"id":"2","text":"bar"}]');
+  });
+
+  it('should return a stringified value that is neither an object nor an array', () => {
+    const result = circularJsonStringify('foo');
+    expect(result).toEqual('"foo"');
+
+    const result2 = circularJsonStringify(1);
+    expect(result2).toEqual('1');
+
+    const result3 = circularJsonStringify(null);
+    expect(result3).toEqual('null');
+
+    const result4 = circularJsonStringify(true);
+    expect(result4).toEqual('true');
+  });
+
+  it('should handle circular references in an object', () => {
+    const comment: Comment = { id: '1', text: 'foo' };
+    comment.parent = comment;
+
+    const result = circularJsonStringify(comment);
+    expect(result).toEqual('{"id":"1","text":"foo","parent":{"$ref":"$"}}');
+  });
+
+  it('should handle non-circular references in an array of objects', () => {
+    const comment1: Comment = { id: '1', text: 'foo' };
+    const comment2: Comment = { id: '2', text: 'bar' };
+
+    comment2.parent = comment1;
+
+    const result = circularJsonStringify([comment1, comment2]);
+    expect(result).toEqual(
+      '[{"id":"1","text":"foo"},{"id":"2","text":"bar","parent":{"$ref":"$[0]"}}]'
+    );
+  });
+
+  it('should handle circular references in an array of objects', () => {
+    const comment1: Comment = { id: '1', text: 'foo' };
+    const comment2: Comment = { id: '2', text: 'bar' };
+
+    comment1.parent = comment1;
+    comment2.parent = comment1;
+
+    const result = circularJsonStringify([comment1, comment2]);
+    expect(result).toEqual(
+      '[{"id":"1","text":"foo","parent":{"$ref":"$[0]"}},{"id":"2","text":"bar","parent":{"$ref":"$[0]"}}]'
+    );
+  });
+
+  it('should handle circular and non-circular references in an array of objects', () => {
+    const comment1: Comment = { id: '1', text: 'foo' };
+    const comment2: Comment = { id: '2', text: 'bar' };
+    const comment3: Comment = { id: '3', text: 'baz' };
+
+    comment1.parent = comment1;
+    comment2.parent = comment1;
+    comment3.parent = comment2;
+
+    const result = circularJsonStringify([comment1, comment2, comment3]);
+    expect(result).toEqual(
+      '[{"id":"1","text":"foo","parent":{"$ref":"$[0]"}},{"id":"2","text":"bar","parent":{"$ref":"$[0]"}},{"id":"3","text":"baz","parent":{"$ref":"$[1]"}}]'
+    );
+  });
+
+  it('should not mutate the original object', () => {
+    const comment: Comment = { id: '1', text: 'foo' };
+    comment.parent = comment;
+
+    circularJsonStringify(comment);
+
+    expect(comment.parent).toBe(comment);
+  });
+});

--- a/packages/sdks/shared/src/lib/utils/circularJsonStringify/circularJsonStringify.ts
+++ b/packages/sdks/shared/src/lib/utils/circularJsonStringify/circularJsonStringify.ts
@@ -1,0 +1,5 @@
+import { decycle } from './cycle';
+
+export const circularJsonStringify = (value: unknown) => {
+  return JSON.stringify(decycle(value));
+};

--- a/packages/sdks/shared/src/lib/utils/circularJsonStringify/cycle.ts
+++ b/packages/sdks/shared/src/lib/utils/circularJsonStringify/cycle.ts
@@ -1,0 +1,98 @@
+/*
+    cycle.js
+    2021-05-31
+
+    Public Domain.
+
+    NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+    https://github.com/douglascrockford/JSON-js/blob/master/cycle.js
+
+    USE YOUR OWN COPY. IT IS EXTREMELY UNWISE TO LOAD CODE FROM SERVERS YOU DO
+    NOT CONTROL.
+*/
+
+export const decycle = function decycle(
+  object: unknown,
+  replacer?: (v: unknown) => unknown
+) {
+  // Make a deep copy of an object or array, assuring that there is at most
+  // one instance of each object or array in the resulting structure. The
+  // duplicate references (which might be forming cycles) are replaced with
+  // an object of the form
+
+  //      {"$ref": PATH}
+
+  // where the PATH is a JSONPath string that locates the first occurance.
+
+  // So,
+
+  //      const a = [];
+  //      a[0] = a;
+  //      return JSON.stringify(decycle(a));
+
+  // produces the string '[{"$ref":"$"}]'.
+
+  // If a replacer function is provided, then it will be called for each value.
+  // A replacer function receives a value and returns a replacement value.
+
+  // JSONPath is used to locate the unique object. $ indicates the top level of
+  // the object or array. [NUMBER] or [STRING] indicates a child element or
+  // property.
+
+  const objects = new WeakMap<object, string>(); // object to path mappings
+
+  return (function derez(value, path) {
+    // The derez function recurses through the object, producing the deep copy.
+
+    // If a replacer function was provided, then call it to get a replacement value.
+
+    if (replacer !== undefined) {
+      value = replacer(value);
+    }
+
+    // typeof null === "object", so go on if this value is really an object but not
+    // one of the weird builtin objects.
+
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      !(value instanceof Boolean) &&
+      !(value instanceof Date) &&
+      !(value instanceof Number) &&
+      !(value instanceof RegExp) &&
+      !(value instanceof String)
+    ) {
+      // If the value is an object or array, look to see if we have already
+      // encountered it. If so, return a {"$ref":PATH} object.
+      const oldPath = objects.get(value);
+
+      if (oldPath !== undefined) {
+        return { $ref: oldPath };
+      }
+
+      // Otherwise, accumulate the unique value and its path.
+      objects.set(value, path);
+
+      // If it is an array, replicate the array.
+      if (Array.isArray(value)) {
+        const newItem: unknown[] = [];
+        value.forEach(function (element, i) {
+          newItem[i] = derez(element, path + '[' + i + ']');
+        });
+        return newItem;
+      } else {
+        // If it is an object, replicate the object.
+        const newItem: { [key: string]: unknown } = {};
+        Object.keys(value).forEach(function (name) {
+          newItem[name] = derez(
+            (value as { [key: string]: unknown })[name],
+            path + '[' + JSON.stringify(name) + ']'
+          );
+        });
+        return newItem;
+      }
+    }
+    return value;
+  })(object, '$');
+};


### PR DESCRIPTION
Introduce a `circularJsonStringify` utility function. Using code from `cycle.js`, this function will simplify references to objects. This results in:

- Objects that a referenced won't be repeated in the stringified json, instead replaced by their path, reducing the size of the string. 
- Circular references won't be an issue anymore because no referenced object will be present in the decycled result. 