### PR TITLE
Privacy Plugin: Check if allowedTrackEvents is set to * and allow all

### DIFF
--- a/packages/plugins/privacy/src/NinetailedPrivacyPlugin.spec.ts
+++ b/packages/plugins/privacy/src/NinetailedPrivacyPlugin.spec.ts
@@ -19,6 +19,8 @@ class TestPlugin extends NinetailedPlugin {
 
   public page = jest.fn();
 
+  public track = jest.fn();
+
   public [SET_ENABLED_FEATURES] = jest.fn();
 }
 
@@ -136,6 +138,15 @@ describe('NinetailedPrivacyPlugin', () => {
 
     await analytics.page();
     expect(testPlugin.page).not.toHaveBeenCalled();
+  });
+
+  it('should not intercept track events if all event names are allowed through *', async () => {
+    const { testPlugin, analytics } = setup({
+      allowedEvents: ['track'],
+      allowedTrackEvents: ['*'],
+    });
+    await analytics.track('test');
+    expect(testPlugin.track).toHaveBeenCalled();
   });
 
   it('Should set the features which are used correctly. E.g. not using the location of the user, even if the consent is given', async () => {

--- a/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
+++ b/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
@@ -80,7 +80,7 @@ export const DEFAULT_PRIVACY_CONFIG: PrivacyConfig = {
   allowedEvents: ['page', 'track'],
   allowedPageEventProperties: ['*'],
   allowedTrackEventProperties: [],
-  allowedTrackEvents: [],
+  allowedTrackEvents: ['*'],
   allowedTraits: [],
   blockProfileMerging: true,
   enabledFeatures: [],
@@ -256,7 +256,10 @@ export class NinetailedPrivacyPlugin extends NinetailedPlugin {
   public [TRACK_EVENT_HANDLER] = this.handleEventStart(
     'track',
     (payload, abort) => {
-      if (!this.getConfig().allowedTrackEvents.includes(payload.event)) {
+      if (
+        !this.getConfig().allowedTrackEvents.includes('*') &&
+        !this.getConfig().allowedTrackEvents.includes(payload.event)
+      ) {
         logger.info(
           '[Ninetailed Privacy Plugin] The track event was blocked, as it is not allowed to send by your configuration.'
         );

--- a/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
+++ b/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
@@ -34,7 +34,7 @@ export type PrivacyConfig = {
   /**
    * Which events you want to allow?
    *
-   * default is ['page', 'track']
+   * default is ['page']
    */
   allowedEvents: EventType[];
   /**
@@ -77,10 +77,10 @@ export type PrivacyConfig = {
 };
 
 export const DEFAULT_PRIVACY_CONFIG: PrivacyConfig = {
-  allowedEvents: ['page', 'track'],
+  allowedEvents: ['page'],
   allowedPageEventProperties: ['*'],
   allowedTrackEventProperties: [],
-  allowedTrackEvents: ['*'],
+  allowedTrackEvents: [],
   allowedTraits: [],
   blockProfileMerging: true,
   enabledFeatures: [],


### PR DESCRIPTION
### **User description**
The Privacy Plugin was ignoring the setting of `allowedTrackEvents: ['*']` and expected every track event name to get listed out. This PR check if `*` is in the list and then allows any event name, no matter which other names are listed.

Potentially, we could change the signature to `string[] | '*'` which makes the typing a bit more explicit.


___

### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced the `NinetailedPrivacyPlugin` to allow all track events if `allowedTrackEvents` is set to include '*'.
- Updated the default privacy configuration to include '*' in `allowedTrackEvents`.
- Added a test case to ensure that track events are not blocked when '*' is specified in `allowedTrackEvents`.
- Introduced a mock function for `track` in the test plugin to verify the behavior.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NinetailedPrivacyPlugin.spec.ts</strong><dd><code>Add test for wildcard track event allowance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/plugins/privacy/src/NinetailedPrivacyPlugin.spec.ts

<li>Added a test to verify that track events are not intercepted when <br><code>allowedTrackEvents</code> includes '*'.<br> <li> Introduced a mock function for <code>track</code> in the <code>TestPlugin</code> class.<br>


</details>


  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/68/files#diff-e4affbc0bc04ce341ae11ea540a352175fa89c421688dae07aebf5a2c5541a08">+11/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NinetailedPrivacyPlugin.ts</strong><dd><code>Allow all track events if wildcard is set</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts

<li>Modified the default configuration to include '*' in <br><code>allowedTrackEvents</code>.<br> <li> Updated the track event handler to allow all events if '*' is present <br>in <code>allowedTrackEvents</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/ninetailed-inc/experience.js/pull/68/files#diff-201595a7aff8e37424c48a5763e7f3287f4761fc8803470edea1485e4740c047">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information