### PR TITLE
fix: prevent dead spot underneath preview widget ribbon

### DIFF
--- a/packages/plugins/preview/src/lib/plugin/NinetailedPreviewPlugin.ts
+++ b/packages/plugins/preview/src/lib/plugin/NinetailedPreviewPlugin.ts
@@ -204,7 +204,7 @@ export class NinetailedPreviewPlugin
 
     if (!this.isKnownAudience(id)) {
       logger.warn(
-        `You cannot deactivate an unkown audience (id: ${id}). How did you get it in the first place?`
+        `You cannot deactivate an unknown audience (id: ${id}). How did you get it in the first place?`
       );
       return;
     }

--- a/packages/plugins/preview/src/lib/plugin/WidgetContainer.ts
+++ b/packages/plugins/preview/src/lib/plugin/WidgetContainer.ts
@@ -17,7 +17,7 @@ type WidgetContainerOptions = {
 
 export class WidgetContainer {
   private static CONTAINER_CLASS = 'nt-preview-widget-container';
-  private container: HTMLDivElement;
+  private readonly container: HTMLDivElement;
 
   constructor(private readonly options: WidgetContainerOptions) {
     this.container = document.createElement('div');
@@ -28,6 +28,7 @@ export class WidgetContainer {
     this.container.style.bottom = `${BUTTON_BOTTOM_POSITION}px`;
     this.container.style.width = `${CONTAINER_WIDTH}px`;
     this.container.style.height = `${BUTTON_HEIGHT}px`;
+    this.container.style.overflow = 'hidden';
     if (options.ui?.opener?.hide) {
       this.container.style.transform = TRANSFORM_CLOSED_HIDE;
     } else {


### PR DESCRIPTION
Related bug ticket with further explanation can be found [here](https://contentful.atlassian.net/browse/DEV-3478).

Preview widget ribbons does not cover the area underneath anymore.
![Bildschirmfoto 2024-12-04 um 09 40 34](https://github.com/user-attachments/assets/ca850251-e7db-482c-a555-2de4127bece0)
