### PR TITLE
fix: stop bundling polyfills

### DIFF
--- a/packages/plugins/analytics/.babelrc
+++ b/packages/plugins/analytics/.babelrc
@@ -1,10 +1,3 @@
 {
-  "presets": [
-    [
-      "@nx/js/babel",
-      {
-        "useBuiltIns": "usage"
-      }
-    ]
-  ]
+  "presets": [["@nx/js/babel"]]
 }

--- a/packages/plugins/insights/.babelrc
+++ b/packages/plugins/insights/.babelrc
@@ -1,10 +1,3 @@
 {
-  "presets": [
-    [
-      "@nx/js/babel",
-      {
-        "useBuiltIns": "usage"
-      }
-    ]
-  ]
+  "presets": [["@nx/js/babel"]]
 }


### PR DESCRIPTION
Only the analytics and insights plugins are bundling their polyfills because of their babel configuration.

Before:
<img width="253" alt="Screenshot 2025-01-21 at 16 13 02" src="https://github.com/user-attachments/assets/74d81e8d-f7c6-4fc9-99f0-474021b7679c" />
<img width="227" alt="Screenshot 2025-01-21 at 16 13 16" src="https://github.com/user-attachments/assets/2d9d11d1-ee86-42d8-8def-6b1e4f849c2a" />

After:
<img width="297" alt="Screenshot 2025-01-21 at 16 12 28" src="https://github.com/user-attachments/assets/4b66f3b0-82a7-43b4-8dd5-58484db05f90" />
<img width="239" alt="Screenshot 2025-01-21 at 16 12 39" src="https://github.com/user-attachments/assets/e234f3f7-ce51-4ff0-9dda-e76a592f48fe" />

