### PR TITLE
Feature/change types

### DIFF
--- a/packages/sdks/javascript/src/lib/Ninetailed.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.ts
@@ -233,6 +233,7 @@ export class Ninetailed implements NinetailedInstance {
       status: 'loading',
       profile: null,
       experiences: null,
+      changes: null,
       error: null,
       from: 'api',
     };
@@ -573,6 +574,7 @@ export class Ninetailed implements NinetailedInstance {
           status: 'error',
           profile: payload.profile,
           experiences: payload.experiences,
+          changes: payload.changes,
           error: payload.error,
         });
       } else {
@@ -581,6 +583,7 @@ export class Ninetailed implements NinetailedInstance {
           status: 'success',
           profile: payload.profile,
           experiences: payload.experiences,
+          changes: payload.changes,
           error: null,
         });
       }

--- a/packages/sdks/javascript/src/lib/Ninetailed.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.ts
@@ -31,6 +31,7 @@ import {
   OnInitProfileId,
   PLUGIN_NAME,
   PROFILE_CHANGE,
+  TypedEventHandlerAnalyticsInstance,
 } from './NinetailedCorePlugin';
 import {
   EventFunctionOptions,
@@ -39,7 +40,6 @@ import {
   OnProfileChangeCallback,
   ProfileState,
   TrackHasSeenComponent,
-  AnalyticsInstance,
   TrackComponentView,
 } from './types';
 import { PAGE_HIDDEN, HAS_SEEN_STICKY_COMPONENT } from './constants';
@@ -142,7 +142,7 @@ const buildOverrideMiddleware =
   };
 
 export class Ninetailed implements NinetailedInstance {
-  private readonly instance: AnalyticsInstance;
+  private readonly instance: TypedEventHandlerAnalyticsInstance;
   private _profileState: ProfileState;
   private isInitialized = false;
   private readonly apiClient: NinetailedApiClient;
@@ -252,7 +252,7 @@ export class Ninetailed implements NinetailedInstance {
       app: 'ninetailed',
       plugins: [...this.plugins, this.ninetailedCorePlugin],
       ...(storageImpl ? { storage: storageImpl } : {}),
-    }) as AnalyticsInstance;
+    }) as TypedEventHandlerAnalyticsInstance;
 
     const detachOnReadyListener = this.instance.on('ready', () => {
       this.isInitialized = true;

--- a/packages/sdks/javascript/src/lib/NinetailedCorePlugin/NinetailedCorePlugin.ts
+++ b/packages/sdks/javascript/src/lib/NinetailedCorePlugin/NinetailedCorePlugin.ts
@@ -15,6 +15,7 @@ import {
   buildComponentViewEvent,
   Profile,
   SelectedVariantInfo,
+  Change,
 } from '@ninetailed/experience.js-shared';
 import {
   NinetailedAnalyticsPlugin,
@@ -25,6 +26,7 @@ import { buildClientNinetailedRequestContext } from './Events';
 import { asyncThrottle } from '../utils/asyncThrottle';
 import {
   ANONYMOUS_ID,
+  CHANGES_FALLBACK_CACHE,
   CONSENT,
   DEBUG_FLAG,
   EMPTY_MERGE_ID,
@@ -382,24 +384,40 @@ export class NinetailedCorePlugin
     this.instance.storage.removeItem(EXPERIENCES_FALLBACK_CACHE);
   }
 
+  private setFallbackChanges(changes: Change[]): void {
+    this.instance.storage.setItem(CHANGES_FALLBACK_CACHE, changes);
+  }
+
+  private getFallbackChanges(): Change[] {
+    return this.instance.storage.getItem(CHANGES_FALLBACK_CACHE) || [];
+  }
+
+  private clearFallbackChanges(): void {
+    this.instance.storage.removeItem(CHANGES_FALLBACK_CACHE);
+  }
+
   private clearCaches(): void {
     this.clearAnonymousId();
     this.clearFallbackProfile();
     this.clearFallbackExperiences();
+    this.clearFallbackChanges();
   }
 
   private populateCaches({
     experiences,
     profile,
     anonymousId,
+    changes,
   }: {
     anonymousId: string;
     profile: Profile;
     experiences: SelectedVariantInfo[];
+    changes: Change[];
   }) {
     this.setAnonymousId(anonymousId);
     this.setFallbackProfile(profile);
     this.setFallbackExperiences(experiences);
+    this.setFallbackChanges(changes);
   }
 
   private async _flush() {
@@ -412,18 +430,20 @@ export class NinetailedCorePlugin
 
     try {
       const anonymousId = this.getAnonymousId();
-      const { profile, experiences } = await this.apiClient.upsertProfile(
-        {
-          profileId: anonymousId,
-          events,
-        },
-        { locale: this.locale, enabledFeatures: this.enabledFeatures }
-      );
+      const { profile, experiences, changes } =
+        await this.apiClient.upsertProfile(
+          {
+            profileId: anonymousId,
+            events,
+          },
+          { locale: this.locale, enabledFeatures: this.enabledFeatures }
+        );
 
       this.populateCaches({
         anonymousId: profile.id,
         profile,
         experiences,
+        changes,
       });
 
       logger.debug('Profile from api: ', profile);
@@ -433,6 +453,7 @@ export class NinetailedCorePlugin
         type: PROFILE_CHANGE,
         profile,
         experiences,
+        changes,
         error: undefined,
       });
       await delay(20);
@@ -441,6 +462,7 @@ export class NinetailedCorePlugin
       logger.debug('An error occurred during flushing the events: ', error);
       const fallbackProfile = this.getFallbackProfile();
       const fallbackExperiences = this.getFallbackExperiences();
+      const fallbackChanges = this.getFallbackChanges();
 
       if (fallbackProfile) {
         logger.debug('Found a fallback profile - will use this.');
@@ -448,6 +470,7 @@ export class NinetailedCorePlugin
           type: PROFILE_CHANGE,
           profile: fallbackProfile,
           experiences: fallbackExperiences,
+          changes: fallbackChanges,
           error: undefined,
         });
       } else {
@@ -456,6 +479,7 @@ export class NinetailedCorePlugin
           type: PROFILE_CHANGE,
           profile: null,
           experiences: fallbackExperiences,
+          changes: fallbackChanges,
           error: error as Error,
         });
       }

--- a/packages/sdks/javascript/src/lib/NinetailedCorePlugin/actions.ts
+++ b/packages/sdks/javascript/src/lib/NinetailedCorePlugin/actions.ts
@@ -1,0 +1,86 @@
+import {
+  HAS_SEEN_COMPONENT,
+  HAS_SEEN_ELEMENT,
+} from '@ninetailed/experience.js-plugin-analytics';
+import {
+  PROFILE_CHANGE,
+  Profile,
+  SelectedVariantInfo,
+  PROFILE_RESET,
+  Change,
+} from '@ninetailed/experience.js-shared';
+import { HAS_SEEN_STICKY_COMPONENT, PAGE_HIDDEN } from '../constants';
+
+type ReadyAction = {
+  type: 'ready';
+};
+
+type HasSeenElementAction = {
+  type: typeof HAS_SEEN_ELEMENT;
+  seenFor: number | undefined;
+  element: Element;
+};
+
+type PageHiddenAction = {
+  type: typeof PAGE_HIDDEN;
+};
+
+type ProfileChangeAction =
+  | {
+      type: typeof PROFILE_CHANGE;
+      profile: Profile;
+      experiences: SelectedVariantInfo[];
+      error: undefined | null;
+    }
+  | {
+      type: typeof PROFILE_CHANGE;
+      profile: Profile | null;
+      experiences: SelectedVariantInfo[];
+      error: Error;
+    };
+
+type ProfileResetAction = {
+  type: typeof PROFILE_RESET;
+};
+
+type ProfileHasSeenStickyComponentAction = {
+  type: typeof HAS_SEEN_STICKY_COMPONENT;
+  componentId: string;
+  experienceId: string | undefined;
+  variantIndex: number | undefined;
+};
+
+type ProfileHasSeenComponentAction = {
+  type: typeof HAS_SEEN_COMPONENT;
+  variant: { id: string };
+  audience: { id: string };
+  isPersonalized: boolean;
+};
+
+// Union type for all possible actions
+export type DispatchAction =
+  | ReadyAction
+  | ProfileChangeAction
+  | ProfileResetAction
+  | ProfileHasSeenStickyComponentAction
+  | HasSeenElementAction
+  | ProfileHasSeenComponentAction
+  | PageHiddenAction;
+
+// This is necessary because when we call `Omit<T, "type">`
+// on a discriminated union,
+// it breaks the discriminated union (see https://github.com/microsoft/TypeScript/issues/31501)
+type RemoveTypeField<Type> = {
+  [Property in keyof Type as Exclude<Property, 'type'>]: Type[Property];
+};
+
+// Mapping from action type to its associated data
+// Utility type to transform each action type into the expected payload format
+export type ExtractPayload<T extends { type: string }> = {
+  payload: RemoveTypeField<T>;
+};
+
+// Dynamically map each action type to its corresponding payload
+export type ActionPayloadMap = {
+  [A in DispatchAction as A['type']]: ExtractPayload<A>;
+};

--- a/packages/sdks/javascript/src/lib/NinetailedCorePlugin/actions.ts
+++ b/packages/sdks/javascript/src/lib/NinetailedCorePlugin/actions.ts
@@ -30,12 +30,14 @@ type ProfileChangeAction =
       type: typeof PROFILE_CHANGE;
       profile: Profile;
       experiences: SelectedVariantInfo[];
+      changes: Change[];
       error: undefined | null;
     }
   | {
       type: typeof PROFILE_CHANGE;
       profile: Profile | null;
       experiences: SelectedVariantInfo[];
+      changes: Change[];
       error: Error;
     };
 

--- a/packages/sdks/javascript/src/lib/NinetailedCorePlugin/constants.ts
+++ b/packages/sdks/javascript/src/lib/NinetailedCorePlugin/constants.ts
@@ -5,6 +5,7 @@ export const DEBUG_FLAG = '__nt_debug__';
 
 export const PROFILE_FALLBACK_CACHE = '__nt_profile__';
 export const EXPERIENCES_FALLBACK_CACHE = '__nt_experiences__';
+export const CHANGES_FALLBACK_CACHE = '__nt_changes__';
 
 export const PROFILE_CHANGE = 'profile-change';
 export const PROFILE_RESET = 'profile-reset';

--- a/packages/sdks/javascript/src/lib/types/index.ts
+++ b/packages/sdks/javascript/src/lib/types/index.ts
@@ -35,8 +35,8 @@ type Success = {
 
 type Fail = {
   status: 'error';
-  profile: null;
-  experiences: null;
+  profile: Profile | null;
+  experiences: SelectedVariantInfo[] | null;
   error: Error;
 };
 

--- a/packages/sdks/javascript/src/lib/types/index.ts
+++ b/packages/sdks/javascript/src/lib/types/index.ts
@@ -8,6 +8,7 @@ import {
   SelectedVariantInfo,
   Reference,
   Event,
+  Change,
 } from '@ninetailed/experience.js-shared';
 import {
   ElementSeenPayload,
@@ -23,6 +24,7 @@ type Loading = {
   status: 'loading';
   profile: null;
   experiences: null;
+  changes: null;
   error: null;
 };
 
@@ -30,6 +32,7 @@ type Success = {
   status: 'success';
   profile: Profile;
   experiences: SelectedVariantInfo[];
+  changes: Change[];
   error: null;
 };
 
@@ -37,6 +40,7 @@ type Fail = {
   status: 'error';
   profile: Profile | null;
   experiences: SelectedVariantInfo[] | null;
+  changes: Change[] | null;
   error: Error;
 };
 

--- a/packages/sdks/react/src/lib/MergeTag/MergeTag.spec.tsx
+++ b/packages/sdks/react/src/lib/MergeTag/MergeTag.spec.tsx
@@ -41,7 +41,7 @@ jest.mock('../useProfile');
 const mockUseProfile = useProfile as jest.MockedFunction<typeof useProfile>;
 
 mockUseProfile.mockReturnValue({
-  loading: false,
+  changes: [],
   from: 'api',
   status: 'success',
   profile: profile,

--- a/packages/sdks/react/src/lib/index.ts
+++ b/packages/sdks/react/src/lib/index.ts
@@ -13,11 +13,7 @@ export { useNinetailed } from './useNinetailed';
 export { useProfile } from './useProfile';
 export { usePersonalize } from './usePersonalize';
 export { useCustomFlag } from './useCustomFlag';
-export type {
-  CustomFlagOptions,
-  CustomFlagResult,
-  CustomFlagStatus,
-} from './useCustomFlag';
+export type { CustomFlagResult, CustomFlagStatus } from './useCustomFlag';
 export { Personalize } from './Personalize';
 export type { PersonalizedComponent } from './Personalize';
 export { MergeTag } from './MergeTag';

--- a/packages/sdks/react/src/lib/index.ts
+++ b/packages/sdks/react/src/lib/index.ts
@@ -12,6 +12,12 @@ export type {
 export { useNinetailed } from './useNinetailed';
 export { useProfile } from './useProfile';
 export { usePersonalize } from './usePersonalize';
+export { useCustomFlag } from './useCustomFlag';
+export type {
+  CustomFlagOptions,
+  CustomFlagResult,
+  CustomFlagStatus,
+} from './useCustomFlag';
 export { Personalize } from './Personalize';
 export type { PersonalizedComponent } from './Personalize';
 export { MergeTag } from './MergeTag';

--- a/packages/sdks/react/src/lib/useCustomFlag.ts
+++ b/packages/sdks/react/src/lib/useCustomFlag.ts
@@ -1,0 +1,122 @@
+import { useState, useEffect } from 'react';
+import { useNinetailed } from './useNinetailed';
+import { logger } from '@ninetailed/experience.js-shared';
+
+export type CustomFlagStatus = 'loading' | 'success' | 'error';
+
+export interface CustomFlagOptions<T> {
+  defaultValue?: T;
+  fallback?: T;
+}
+
+export interface CustomFlagResult<T> {
+  value: T | null;
+  isLoading: boolean;
+  status: CustomFlagStatus;
+  error: Error | null;
+}
+
+export function useCustomFlag<T>(
+  flagKey: string,
+  options: CustomFlagOptions<T> = {}
+): CustomFlagResult<T> {
+  const { defaultValue, fallback } = options;
+  const ninetailed = useNinetailed();
+  const [result, setResult] = useState<CustomFlagResult<T>>({
+    value: defaultValue || null,
+    isLoading: true,
+    status: 'loading',
+    error: null,
+  });
+
+  useEffect(() => {
+    console.log(`[useCustomFlag] Initializing hook for flag: ${flagKey}`);
+
+    const unsubscribe = ninetailed.onProfileChange((profileState) => {
+      console.log(
+        `[useCustomFlag] Profile state changed for flag: ${flagKey}`,
+        profileState
+      );
+
+      if (profileState.status === 'loading') {
+        console.log(`[useCustomFlag] Still loading flag: ${flagKey}`);
+        return;
+      }
+
+      if (profileState.status === 'error') {
+        console.log(
+          `[useCustomFlag] Error loading flag: ${flagKey}`,
+          profileState.error
+        );
+        setResult({
+          value: fallback !== undefined ? fallback : defaultValue || null,
+          isLoading: false,
+          status: 'error',
+          error: profileState.error,
+        });
+        return;
+      }
+
+      console.log(
+        `[useCustomFlag] Profile loaded, looking for flag: ${flagKey}`
+      );
+
+      try {
+        // Extract custom flag value from the changes array
+        let flagValue: T | undefined = undefined;
+
+        // Check if we have changes array in the profile state
+        if (profileState.changes && Array.isArray(profileState.changes)) {
+          // Find the change with our flag key
+          const change = profileState.changes.find(
+            (change) => change.key === flagKey
+          );
+
+          if (change && change.type === 'Variable') {
+            flagValue = change.value as unknown as T;
+            console.log(
+              `[useCustomFlag] Found flag ${flagKey} with value:`,
+              flagValue
+            );
+          }
+        }
+
+        setResult({
+          value:
+            flagValue !== undefined
+              ? flagValue
+              : fallback !== undefined
+              ? fallback
+              : defaultValue || null,
+          isLoading: false,
+          status: 'success',
+          error: null,
+        });
+
+        console.log(
+          `[useCustomFlag] Flag ${flagKey} processing complete. Final value:`,
+          flagValue !== undefined
+            ? flagValue
+            : fallback !== undefined
+            ? fallback
+            : defaultValue || null
+        );
+      } catch (error) {
+        console.error(
+          `[useCustomFlag] Error extracting flag ${flagKey}:`,
+          error
+        );
+        setResult({
+          value: fallback !== undefined ? fallback : defaultValue || null,
+          isLoading: false,
+          status: 'error',
+          error: error instanceof Error ? error : new Error(String(error)),
+        });
+      }
+    });
+
+    return unsubscribe;
+  }, [flagKey, defaultValue, fallback, ninetailed]);
+
+  return result;
+}

--- a/packages/sdks/shared/src/index.ts
+++ b/packages/sdks/shared/src/index.ts
@@ -1,5 +1,6 @@
 // types
-export * from './lib/types/Endpoints/CreateProfile';
+
+export * from './lib/types/Changes';
 export * from './lib/types/Endpoints/UpdateProfile';
 export * from './lib/types/Endpoints/UpsertManyProfiles';
 export * from './lib/types/Endpoints/RequestBodyOptions';

--- a/packages/sdks/shared/src/lib/types/Changes/Changes.ts
+++ b/packages/sdks/shared/src/lib/types/Changes/Changes.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+import { JsonObject } from '../generic/Json';
+
+const Variable = 'Variable';
+
+const ChangeBase = z.object({
+  key: z.string(),
+  type: z.enum([Variable]),
+});
+
+export const VariableChange = ChangeBase.extend({
+  type: z.literal(Variable),
+  value: z.union([z.string(), JsonObject]),
+});
+
+export const Change = z.discriminatedUnion('type', [VariableChange]);
+
+export type Change = z.infer<typeof Change>;
+export const ChangeTypes = {
+  Variable,
+};

--- a/packages/sdks/shared/src/lib/types/Changes/Changes.ts
+++ b/packages/sdks/shared/src/lib/types/Changes/Changes.ts
@@ -8,6 +8,8 @@ const ChangeBase = z.object({
   type: z.enum([Variable]),
 });
 
+export type AllowedVariableType = string | JsonObject;
+
 export const VariableChange = ChangeBase.extend({
   type: z.literal(Variable),
   value: z.union([z.string(), JsonObject]),

--- a/packages/sdks/shared/src/lib/types/Changes/index.ts
+++ b/packages/sdks/shared/src/lib/types/Changes/index.ts
@@ -1,0 +1,1 @@
+export * from './Changes';

--- a/packages/sdks/shared/src/lib/types/Endpoints/CreateProfile.ts
+++ b/packages/sdks/shared/src/lib/types/Endpoints/CreateProfile.ts
@@ -15,7 +15,8 @@ export const CreateProfileResponse = withResponseEnvelope(
   z.object({
     profile: Profile,
     experiences: z.array(SelectedVariantInfo),
-    changes: z.array(Change),
+    // TODO: Remove default once the API sends it
+    changes: z.array(Change).default([]),
   })
 );
 export type CreateProfileResponse = z.infer<typeof CreateProfileResponse>;

--- a/packages/sdks/shared/src/lib/types/Endpoints/CreateProfile.ts
+++ b/packages/sdks/shared/src/lib/types/Endpoints/CreateProfile.ts
@@ -3,6 +3,7 @@ import { Profile } from '../Profile/Profile';
 import { RequestBodyOptions } from './RequestBodyOptions';
 import { SelectedVariantInfo } from '../SelectedVariantInfo/SelectedVariantInfo';
 import { withResponseEnvelope } from './shared';
+import { Change } from '../Changes';
 
 export const CreateProfileRequestBody = z.object({
   events: z.array(z.unknown()).min(1),
@@ -14,6 +15,7 @@ export const CreateProfileResponse = withResponseEnvelope(
   z.object({
     profile: Profile,
     experiences: z.array(SelectedVariantInfo),
+    changes: z.array(Change),
   })
 );
 export type CreateProfileResponse = z.infer<typeof CreateProfileResponse>;

--- a/packages/sdks/shared/src/lib/types/Endpoints/GetProfile.ts
+++ b/packages/sdks/shared/src/lib/types/Endpoints/GetProfile.ts
@@ -8,7 +8,8 @@ export const GetProfileResponse = withResponseEnvelope(
   z.object({
     profile: Profile,
     experiences: z.array(SelectedVariantInfo),
-    changes: z.array(Change),
+    // TODO: Remove default once the API sends it
+    changes: z.array(Change).default([]),
   })
 );
 export type GetProfileResponse = z.infer<typeof GetProfileResponse>;

--- a/packages/sdks/shared/src/lib/types/Endpoints/GetProfile.ts
+++ b/packages/sdks/shared/src/lib/types/Endpoints/GetProfile.ts
@@ -2,11 +2,13 @@ import { z } from 'zod';
 import { Profile } from '../Profile/Profile';
 import { SelectedVariantInfo } from '../SelectedVariantInfo/SelectedVariantInfo';
 import { withResponseEnvelope } from './shared';
+import { Change } from '../Changes';
 
 export const GetProfileResponse = withResponseEnvelope(
   z.object({
     profile: Profile,
     experiences: z.array(SelectedVariantInfo),
+    changes: z.array(Change),
   })
 );
 export type GetProfileResponse = z.infer<typeof GetProfileResponse>;

--- a/packages/sdks/shared/src/lib/types/Endpoints/UpdateProfile.ts
+++ b/packages/sdks/shared/src/lib/types/Endpoints/UpdateProfile.ts
@@ -15,7 +15,8 @@ export const UpdateProfileResponse = withResponseEnvelope(
   z.object({
     profile: Profile,
     experiences: z.array(SelectedVariantInfo),
-    changes: z.array(Change),
+    // TODO: Remove default once the API sends it
+    changes: z.array(Change).default([]),
   })
 );
 export type UpdateProfileResponse = z.infer<typeof UpdateProfileResponse>;

--- a/packages/sdks/shared/src/lib/types/Endpoints/UpdateProfile.ts
+++ b/packages/sdks/shared/src/lib/types/Endpoints/UpdateProfile.ts
@@ -3,6 +3,7 @@ import { Profile } from '../Profile/Profile';
 import { RequestBodyOptions } from './RequestBodyOptions';
 import { SelectedVariantInfo } from '../SelectedVariantInfo/SelectedVariantInfo';
 import { withResponseEnvelope } from './shared';
+import { Change } from '../Changes';
 
 export const UpdateProfileRequestBody = z.object({
   events: z.array(z.unknown()).min(1),
@@ -14,6 +15,7 @@ export const UpdateProfileResponse = withResponseEnvelope(
   z.object({
     profile: Profile,
     experiences: z.array(SelectedVariantInfo),
+    changes: z.array(Change),
   })
 );
 export type UpdateProfileResponse = z.infer<typeof UpdateProfileResponse>;

--- a/packages/sdks/shared/src/lib/types/SelectedVariantInfo/ProfileWithSelectedVariants.ts
+++ b/packages/sdks/shared/src/lib/types/SelectedVariantInfo/ProfileWithSelectedVariants.ts
@@ -1,7 +1,9 @@
+import { Change } from '../Changes';
 import { Profile } from '../Profile/Profile';
 import { SelectedVariantInfo } from './SelectedVariantInfo';
 
 export type ProfileWithSelectedVariants = {
   profile: Profile;
   experiences: SelectedVariantInfo[];
+  changes: Change[];
 };


### PR DESCRIPTION
Making the branch merge to main for purposes of creating the PR, the destination branch will be changes later once i understand the merging strategy needed for this repo.

Main changes:
- Added support for our new "change" types into the SDK.
- Improve type safety in the NinetailedCorePlugin and the Ninetailed class.
- Added a useCustomFlag hook that retrieve a specific feature flag from the Ninetailed profile.
- fixed bug where  the useProfile hook was creating a new object every time, even when the data inside hadn't changed.
  - **_What this caused:_** When you used this object in a useEffect dependency array, the effect would run on every render because React saw a "new" object each time.
  - **_The loop it created:_** Component renders --> useProfile returns a new object --> useEffect sees a "new" dependency and runs again --> The effect updates state --> This causes another render --> The cycle repeats endlessly.