### PR TITLE
fix: restructure useProfile hook to exclude 'experiences' from state,…

### DIFF
--- a/packages/playgrounds/easy-hr/components/HubspotForm/HubspotForm.tsx
+++ b/packages/playgrounds/easy-hr/components/HubspotForm/HubspotForm.tsx
@@ -7,8 +7,7 @@ import { useNinetailed, useProfile } from '@ninetailed/experience.js-next';
 import { IHubspotForm } from '@/types/contentful';
 
 export const HubspotForm: React.FC<IHubspotForm> = ({ fields }) => {
-  const { profile, status } = useProfile();
-  const loading = status === 'loading';
+  const { profile, loading } = useProfile();
   const { identify } = useNinetailed();
   const [anonymousIdInput, setAnonymousIdInput] = useState(null);
   const [submitData, setSubmitData] = useState(null);

--- a/packages/playgrounds/easy-hr/components/HubspotForm/HubspotForm.tsx
+++ b/packages/playgrounds/easy-hr/components/HubspotForm/HubspotForm.tsx
@@ -7,7 +7,8 @@ import { useNinetailed, useProfile } from '@ninetailed/experience.js-next';
 import { IHubspotForm } from '@/types/contentful';
 
 export const HubspotForm: React.FC<IHubspotForm> = ({ fields }) => {
-  const { loading, profile } = useProfile();
+  const { profile, status } = useProfile();
+  const loading = status === 'loading';
   const { identify } = useNinetailed();
   const [anonymousIdInput, setAnonymousIdInput] = useState(null);
   const [submitData, setSubmitData] = useState(null);

--- a/packages/sdks/react/src/lib/MergeTag/MergeTag.spec.tsx
+++ b/packages/sdks/react/src/lib/MergeTag/MergeTag.spec.tsx
@@ -41,6 +41,7 @@ jest.mock('../useProfile');
 const mockUseProfile = useProfile as jest.MockedFunction<typeof useProfile>;
 
 mockUseProfile.mockReturnValue({
+  loading: false,
   from: 'api',
   status: 'success',
   profile: profile,

--- a/packages/sdks/react/src/lib/MergeTag/MergeTag.spec.tsx
+++ b/packages/sdks/react/src/lib/MergeTag/MergeTag.spec.tsx
@@ -41,7 +41,6 @@ jest.mock('../useProfile');
 const mockUseProfile = useProfile as jest.MockedFunction<typeof useProfile>;
 
 mockUseProfile.mockReturnValue({
-  loading: false,
   from: 'api',
   status: 'success',
   profile: profile,

--- a/packages/sdks/react/src/lib/MergeTag/MergeTag.tsx
+++ b/packages/sdks/react/src/lib/MergeTag/MergeTag.tsx
@@ -11,7 +11,8 @@ export const MergeTag = ({
   id,
   fallback,
 }: PropsWithChildren<MergeTagProps>) => {
-  const { loading, profile } = useProfile();
+  const { status, profile } = useProfile();
+  const loading = status === 'loading';
 
   if (loading || !profile) {
     return null;

--- a/packages/sdks/react/src/lib/MergeTag/MergeTag.tsx
+++ b/packages/sdks/react/src/lib/MergeTag/MergeTag.tsx
@@ -11,8 +11,7 @@ export const MergeTag = ({
   id,
   fallback,
 }: PropsWithChildren<MergeTagProps>) => {
-  const { status, profile } = useProfile();
-  const loading = status === 'loading';
+  const { profile, loading } = useProfile();
 
   if (loading || !profile) {
     return null;

--- a/packages/sdks/react/src/lib/useProfile.ts
+++ b/packages/sdks/react/src/lib/useProfile.ts
@@ -28,10 +28,8 @@ function formatProfileForHook(profile: ProfileState): UseProfileHookResult {
  * @returns The profile state without the 'experiences' property
  */
 export const useProfile = (): UseProfileHookResult => {
-  // Get the Ninetailed instance
   const ninetailed = useNinetailed();
 
-  // State to hold the stripped profile state
   const [strippedProfileState, setStrippedProfileState] =
     useState<UseProfileHookResult>(
       formatProfileForHook(ninetailed.profileState)
@@ -41,7 +39,6 @@ export const useProfile = (): UseProfileHookResult => {
   const profileStateRef = useRef(ninetailed.profileState);
 
   useEffect(() => {
-    // Subscribe to profile changes
     const unsubscribe = ninetailed.onProfileChange((changedProfileState) => {
       // Skip update if the profile hasn't actually changed
       // Here we compare the entire profile including experiences and changes
@@ -50,7 +47,6 @@ export const useProfile = (): UseProfileHookResult => {
         return;
       }
 
-      // Update the ref and log the change
       profileStateRef.current = changedProfileState;
       logger.debug('Profile State Changed', changedProfileState);
 
@@ -64,7 +60,7 @@ export const useProfile = (): UseProfileHookResult => {
         logger.debug('Unsubscribed from profile state changes');
       }
     };
-  }, []); // Empty dependency array means this effect runs once on mount
+  }, []);
 
   return strippedProfileState;
 };

--- a/packages/sdks/react/src/lib/useProfile.ts
+++ b/packages/sdks/react/src/lib/useProfile.ts
@@ -32,9 +32,10 @@ export const useProfile = (): UseProfileHookResult => {
   const ninetailed = useNinetailed();
 
   // State to hold the stripped profile state
-  const [strippedProfileState, setStrippedProfileState] = useState<
-    Omit<ProfileState, 'experiences'> & { loading: boolean }
-  >(formatProfileForHook(ninetailed.profileState));
+  const [strippedProfileState, setStrippedProfileState] =
+    useState<UseProfileHookResult>(
+      formatProfileForHook(ninetailed.profileState)
+    );
 
   // Reference to track the previous profile state for comparison
   const profileStateRef = useRef(ninetailed.profileState);

--- a/packages/sdks/react/src/lib/useProfile.ts
+++ b/packages/sdks/react/src/lib/useProfile.ts
@@ -25,8 +25,11 @@ export const useProfile = () => {
 
   // State to hold the stripped profile state
   const [strippedProfileState, setStrippedProfileState] = useState<
-    Omit<ProfileState, 'experiences'>
-  >(profileStateWithoutExperiences);
+    Omit<ProfileState, 'experiences'> & { loading: boolean }
+  >({
+    ...profileStateWithoutExperiences,
+    loading: ninetailed.profileState.status === 'loading',
+  });
 
   // Reference to track the previous profile state for comparison
   const profileStateRef = useRef(ninetailed.profileState);
@@ -35,6 +38,7 @@ export const useProfile = () => {
     // Subscribe to profile changes
     const unsubscribe = ninetailed.onProfileChange((changedProfileState) => {
       // Skip update if the profile hasn't actually changed
+      // Here we compare the entire profile including experiences and changes
       if (isEqual(changedProfileState, profileStateRef.current)) {
         logger.debug('Profile State Did Not Change', changedProfileState);
         return;
@@ -47,7 +51,10 @@ export const useProfile = () => {
       // Extract everything except experiences and update state
       const { experiences, ...profileStateWithoutExperiences } =
         changedProfileState;
-      setStrippedProfileState(profileStateWithoutExperiences);
+      setStrippedProfileState({
+        ...profileStateWithoutExperiences,
+        loading: changedProfileState.status === 'loading',
+      });
     });
 
     // Clean up subscription when component unmounts


### PR DESCRIPTION
- fixed bug where the useProfile hook was creating a new object every time, even when the data inside hadn't changed.
  - **_What this caused:_** When you used this object in a useEffect dependency array, the effect would run on every render - because React saw a "new" object each time.
  - **_The loop it created:_** Component renders --> useProfile returns a new object --> useEffect sees a "new" dependency and runs again --> The effect updates state --> This causes another render --> The cycle repeats endlessly.