### PR TITLE
feat: add SerializableObject type and related components to experienc…

### DIFF
--- a/packages/plugins/preview/src/lib/plugin/NinetailedPreviewPlugin.ts
+++ b/packages/plugins/preview/src/lib/plugin/NinetailedPreviewPlugin.ts
@@ -1,4 +1,6 @@
 import {
+  ComponentTypeEnum,
+  EntryReplacement,
   logger,
   Profile,
   Reference,
@@ -364,9 +366,17 @@ export class NinetailedPreviewPlugin
         };
       }
 
-      const baselineComponent = experience.components.find(
+      // Handle entry replacements as before
+      const entryReplacementComponents = experience.components.filter(
+        (component): component is EntryReplacement<Reference> =>
+          component.type === ComponentTypeEnum.EntryReplacement &&
+          'id' in component.baseline
+      );
+
+      const baselineComponent = entryReplacementComponents.find(
         (component) => component.baseline.id === baseline.id
       );
+
       if (!baselineComponent) {
         return {
           experience,

--- a/packages/sdks/javascript/src/lib/experience/types/index.ts
+++ b/packages/sdks/javascript/src/lib/experience/types/index.ts
@@ -3,7 +3,8 @@ export type {
   Baseline,
   VariantRef,
   ExperienceConfiguration,
-  BaselineWithVariants,
+  EntryReplacement,
+  InlineVariable,
   Distribution,
   ExperienceType,
 } from '@ninetailed/experience.js-shared';

--- a/packages/sdks/react/src/lib/Experience/ESRLoadingComponent.tsx
+++ b/packages/sdks/react/src/lib/Experience/ESRLoadingComponent.tsx
@@ -65,11 +65,17 @@ export const ESRLoadingComponent = <
     );
   }
 
-  const component = experience.components.find(
-    (component) =>
-      'id' in component.baseline &&
-      component.baseline.id === ('id' in baseline ? baseline.id : undefined)
-  );
+  const component = experience.components.find((component) => {
+    if (!('id' in component.baseline)) {
+      return false;
+    }
+
+    if (!('id' in baseline)) {
+      return component.baseline.id === undefined;
+    }
+
+    return component.baseline.id === baseline.id;
+  });
 
   if (!component) {
     return (

--- a/packages/sdks/react/src/lib/Experience/ESRLoadingComponent.tsx
+++ b/packages/sdks/react/src/lib/Experience/ESRLoadingComponent.tsx
@@ -66,7 +66,9 @@ export const ESRLoadingComponent = <
   }
 
   const component = experience.components.find(
-    (component) => component.baseline.id === baseline.id
+    (component) =>
+      'id' in component.baseline &&
+      component.baseline.id === ('id' in baseline ? baseline.id : undefined)
   );
 
   if (!component) {

--- a/packages/sdks/react/src/lib/Experience/types/BaselineWithVariants.ts
+++ b/packages/sdks/react/src/lib/Experience/types/BaselineWithVariants.ts
@@ -1,6 +1,7 @@
 import { Baseline } from './Baseline';
 import { Variant } from './Variant';
 
+// TODO: Is this used anywhere or needed? if needed then we need to update it to match the rest of the types in the JS SDK
 export type BaselineWithVariants = {
   // The Baseline with Variants here is not resolved to it's props. No type needed.
   baseline: Baseline;

--- a/packages/sdks/react/src/lib/Experience/useExperience.spec.tsx
+++ b/packages/sdks/react/src/lib/Experience/useExperience.spec.tsx
@@ -184,7 +184,7 @@ describe('useExperience', () => {
       }
     );
 
-    await sleep(5);
+    await sleep(10);
 
     await act(async () => {
       ninetailed.identify('test');

--- a/packages/sdks/react/src/lib/Experience/useExperience.spec.tsx
+++ b/packages/sdks/react/src/lib/Experience/useExperience.spec.tsx
@@ -3,7 +3,10 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { act, renderHook } from '@testing-library/react';
 
 import { Ninetailed } from '@ninetailed/experience.js';
-import { NinetailedApiClient } from '@ninetailed/experience.js-shared';
+import {
+  ComponentTypeEnum,
+  NinetailedApiClient,
+} from '@ninetailed/experience.js-shared';
 
 import { useExperience } from './useExperience';
 import { NinetailedContext } from '../NinetailedContext';
@@ -78,6 +81,7 @@ describe('useExperience', () => {
           baseline: {
             id: '32WvgBhIZI1HLS4MvWjkvb',
           },
+          type: ComponentTypeEnum.EntryReplacement,
           variants: [
             {
               id: '43SvtAkZ3zTzPnlD3N38V2',
@@ -93,7 +97,15 @@ describe('useExperience', () => {
           baseline: {
             id: '32WvgBhIZI1HLS4MvWjkvb',
           },
-          experiences: [experience],
+          experiences: [
+            {
+              ...experience,
+              components: experience.components.map((component) => ({
+                ...component,
+                type: ComponentTypeEnum.EntryReplacement,
+              })),
+            },
+          ],
         }),
       {
         wrapper: createNinetailedContextWrapper(ninetailed),
@@ -135,6 +147,7 @@ describe('useExperience', () => {
       trafficAllocation: 1,
       components: [
         {
+          type: ComponentTypeEnum.EntryReplacement,
           baseline: {
             id: '4hXsA6l0nWtToi8eWQmJ4n',
           },
@@ -156,7 +169,15 @@ describe('useExperience', () => {
           baseline: {
             id: '4hXsA6l0nWtToi8eWQmJ4n',
           },
-          experiences: [experience],
+          experiences: [
+            {
+              ...experience,
+              components: experience.components.map((component) => ({
+                ...component,
+                type: ComponentTypeEnum.EntryReplacement,
+              })),
+            },
+          ],
         }),
       {
         wrapper: createNinetailedContextWrapper(ninetailed),

--- a/packages/sdks/shared/src/index.ts
+++ b/packages/sdks/shared/src/index.ts
@@ -38,6 +38,8 @@ export * from './lib/types/Session/SessionStatistics';
 
 export * from './lib/types/ExperienceDefinition';
 
+export * from './lib/types/SerializableObject/SerializableObject';
+
 export * from './lib/constants';
 
 // api

--- a/packages/sdks/shared/src/lib/types/ExperienceDefinition/BaselineWithVariants.ts
+++ b/packages/sdks/shared/src/lib/types/ExperienceDefinition/BaselineWithVariants.ts
@@ -1,8 +1,28 @@
+import { SerializableObject } from '../SerializableObject/SerializableObject';
 import { Baseline } from './Baseline';
 import { Reference } from './Reference';
 import { VariantRef } from './VariantRef';
 
-export type BaselineWithVariants<Variant extends Reference> = {
+export enum ComponentTypeEnum {
+  EntryReplacement = 'EntryReplacement',
+  InlineVariable = 'InlineVariable',
+}
+
+enum InlineVariableComponentValueTypeEnum {
+  String = 'String',
+  Object = 'Object',
+}
+
+export type EntryReplacement<Variant extends Reference> = {
+  type: ComponentTypeEnum.EntryReplacement;
   baseline: Baseline;
   variants: (Variant | VariantRef)[];
+};
+
+export type InlineVariable = {
+  type: ComponentTypeEnum.InlineVariable;
+  key: string;
+  valueType: InlineVariableComponentValueTypeEnum;
+  baseline: { value: string | SerializableObject };
+  variants: { value: string | SerializableObject }[];
 };

--- a/packages/sdks/shared/src/lib/types/ExperienceDefinition/ExperienceConfiguration.ts
+++ b/packages/sdks/shared/src/lib/types/ExperienceDefinition/ExperienceConfiguration.ts
@@ -1,8 +1,10 @@
-import { BaselineWithVariants } from './BaselineWithVariants';
+import { z } from 'zod';
+import { EntryReplacement, InlineVariable } from './BaselineWithVariants';
 import { Distribution } from './Distribution';
 import { Reference } from './Reference';
 
 export type ExperienceType = 'nt_personalization' | 'nt_experiment';
+export const ExperienceType = z.enum(['nt_personalization', 'nt_experiment']);
 
 export type ExperienceConfiguration<Variant extends Reference = Reference> = {
   id: string;
@@ -18,5 +20,5 @@ export type ExperienceConfiguration<Variant extends Reference = Reference> = {
   distribution: Distribution[];
   sticky?: boolean;
 
-  components: BaselineWithVariants<Variant>[];
+  components: (EntryReplacement<Variant> | InlineVariable)[];
 };

--- a/packages/sdks/shared/src/lib/types/ExperienceDefinition/index.ts
+++ b/packages/sdks/shared/src/lib/types/ExperienceDefinition/index.ts
@@ -1,7 +1,8 @@
 export type { Reference } from './Reference';
 export type { Baseline } from './Baseline';
 export type { VariantRef } from './VariantRef';
-export type { BaselineWithVariants } from './BaselineWithVariants';
+export type { EntryReplacement, InlineVariable } from './BaselineWithVariants';
+export { ComponentTypeEnum } from './BaselineWithVariants';
 export type { Distribution } from './Distribution';
 
 export type {

--- a/packages/sdks/shared/src/lib/types/SerializableObject/SerializableObject.ts
+++ b/packages/sdks/shared/src/lib/types/SerializableObject/SerializableObject.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+type SerializableValue =
+  | string
+  | number
+  | boolean
+  | null
+  | SerializableObject
+  | SerializableValue[];
+
+export const SerializableValue: z.ZodType<SerializableValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    SerializableObject,
+    z.array(SerializableValue),
+  ])
+);
+
+export type SerializableObject = {
+  [key: string]: SerializableValue | SerializableValue[];
+};
+export const SerializableObject: z.ZodType<SerializableObject> = z.lazy(() =>
+  z.record(z.string(), z.union([SerializableValue, z.array(SerializableValue)]))
+);

--- a/packages/sdks/shared/src/lib/utils/experiences/selectBaselineWithVariants.ts
+++ b/packages/sdks/shared/src/lib/utils/experiences/selectBaselineWithVariants.ts
@@ -1,6 +1,7 @@
 import {
   Baseline,
-  BaselineWithVariants,
+  EntryReplacement,
+  ComponentTypeEnum,
   ExperienceConfiguration,
   Reference,
 } from '../../types/ExperienceDefinition';
@@ -8,10 +9,13 @@ import {
 export const selectBaselineWithVariants = <TVariant extends Reference>(
   experience: ExperienceConfiguration<TVariant>,
   baseline: Baseline
-): BaselineWithVariants<TVariant> | null => {
-  return (
-    experience.components.find(
-      (baselineWithVariants) => baselineWithVariants.baseline.id === baseline.id
-    ) ?? null
+): EntryReplacement<TVariant> | null => {
+  const component = experience.components.find(
+    (entryReplacement) =>
+      'id' in entryReplacement.baseline &&
+      entryReplacement.baseline.id === baseline.id
   );
+  return component?.type === ComponentTypeEnum.EntryReplacement
+    ? component
+    : null;
 };

--- a/packages/utils/contentful/src/lib/__test__/ExperienceMapper.spec.ts
+++ b/packages/utils/contentful/src/lib/__test__/ExperienceMapper.spec.ts
@@ -100,7 +100,7 @@ describe('Contentful Experience Mapper', () => {
       expect(mappedExperience.audience?.name).not.toBeUndefined();
       mappedExperience.components.forEach((component) => {
         component.variants.forEach((variant) => {
-          expect(variant.id).not.toBeUndefined();
+          expect('id' in variant).not.toBeUndefined();
 
           if ('headline' in variant) {
             expect(variant.headline).not.toBeUndefined();

--- a/packages/utils/contentful/src/lib/__test__/ExperienceMapper.spec.ts
+++ b/packages/utils/contentful/src/lib/__test__/ExperienceMapper.spec.ts
@@ -100,7 +100,7 @@ describe('Contentful Experience Mapper', () => {
       expect(mappedExperience.audience?.name).not.toBeUndefined();
       mappedExperience.components.forEach((component) => {
         component.variants.forEach((variant) => {
-          expect('id' in variant).not.toBeUndefined();
+          expect('id' in variant).toBe(true);
 
           if ('headline' in variant) {
             expect(variant.headline).not.toBeUndefined();

--- a/packages/utils/contentful/src/lib/__test__/__snapshots__/ExperienceMapper.spec.ts.snap
+++ b/packages/utils/contentful/src/lib/__test__/__snapshots__/ExperienceMapper.spec.ts.snap
@@ -11,8 +11,10 @@ Array [
     "components": Array [
       Object {
         "baseline": Object {
+          "hidden": false,
           "id": "2t0zGNkAgnSyhUAFigL1Fe",
         },
+        "type": "EntryReplacement",
         "variants": Array [
           Object {
             "headline": "[Ninetailed Variant] Home Page Hero Banner",

--- a/packages/utils/contentful/src/types/__snapshots__/ExperienceEntry.spec.ts.snap
+++ b/packages/utils/contentful/src/types/__snapshots__/ExperienceEntry.spec.ts.snap
@@ -8,6 +8,7 @@ Object {
       "components": Array [
         Object {
           "baseline": Object {
+            "hidden": false,
             "id": "50LFM6YHR9NoqPilYKEGeT",
           },
           "variants": Array [

--- a/packages/utils/javascript/src/lib/ExperienceMapper.spec.ts
+++ b/packages/utils/javascript/src/lib/ExperienceMapper.spec.ts
@@ -93,7 +93,9 @@ describe('Experience Mapper', () => {
     const variant = mapped.components[0].variants[0];
     if (!('hidden' in variant)) {
       // Yeay! It correctly inferred the type of the property "foo" on the variant
-      expect(variant.foo).toBe('bar');
+      if ('foo' in variant) {
+        expect(variant.foo).toBe('bar');
+      }
     }
 
     expect(mapped.components[0].variants).toStrictEqual([

--- a/packages/utils/javascript/src/lib/ExperienceMapper.ts
+++ b/packages/utils/javascript/src/lib/ExperienceMapper.ts
@@ -70,7 +70,7 @@ export class ExperienceMapper {
                 (variant) => variant.id === variantRef.id
               );
 
-              return matchingVariant || null;
+              return matchingVariant ?? null;
             })
             .filter((variant): variant is Variant => variant !== null);
 
@@ -79,11 +79,11 @@ export class ExperienceMapper {
             baseline: component.baseline,
             variants: processedVariants,
           };
-        } else if (isInlineVariableComponent(component)) {
-          return component;
-        } else {
-          throw new Error(`Unsupported component type encountered`);
         }
+        if (isInlineVariableComponent(component)) {
+          return component;
+        }
+        throw new Error(`Unsupported component type encountered`);
       }),
     };
   }

--- a/packages/utils/javascript/src/lib/ExperienceMapper.ts
+++ b/packages/utils/javascript/src/lib/ExperienceMapper.ts
@@ -11,6 +11,7 @@ import { ExperimentLike } from '../types/Experiment';
 import {
   ComponentTypeEnum,
   isEntryReplacementComponent,
+  isInlineVariableComponent,
 } from '../types/Config';
 
 export class ExperienceMapper {
@@ -78,15 +79,10 @@ export class ExperienceMapper {
             baseline: component.baseline,
             variants: processedVariants,
           };
+        } else if (isInlineVariableComponent(component)) {
+          return component;
         } else {
-          const inlineComponent = component;
-          return {
-            type: ComponentTypeEnum.InlineVariable,
-            baseline: inlineComponent.baseline,
-            key: inlineComponent.key,
-            valueType: inlineComponent.valueType,
-            variants: inlineComponent.variants,
-          };
+          throw new Error(`Unsupported component type encountered`);
         }
       }),
     };

--- a/packages/utils/javascript/src/lib/ExperienceMapper.ts
+++ b/packages/utils/javascript/src/lib/ExperienceMapper.ts
@@ -8,6 +8,10 @@ import { logger } from '@ninetailed/experience.js-shared';
 import { Experiment } from '../types/Experiment';
 import { Experience, ExperienceLike } from '../types/Experience';
 import { ExperimentLike } from '../types/Experiment';
+import {
+  ComponentTypeEnum,
+  isEntryReplacementComponent,
+} from '../types/Config';
 
 export class ExperienceMapper {
   static isExperienceEntry<Variant extends Reference>(
@@ -52,22 +56,39 @@ export class ExperienceMapper {
         end: config.distribution.slice(0, index + 1).reduce((a, b) => a + b, 0),
       })),
       sticky,
-      components: components.map((component) => ({
-        baseline: component.baseline,
-        variants: component.variants
-          .map((variantRef) => {
-            if (variantRef.hidden) {
-              return variantRef;
-            }
+      components: components.map((component) => {
+        if (isEntryReplacementComponent(component)) {
+          // Process EntryReplacement component
+          const processedVariants = component.variants
+            .map((variantRef) => {
+              if (variantRef.hidden) {
+                return variantRef;
+              }
 
-            const matchingVariant = variants.find(
-              (variant) => variant.id === variantRef.id
-            );
+              const matchingVariant = variants.find(
+                (variant) => variant.id === variantRef.id
+              );
 
-            return matchingVariant ?? null;
-          })
-          .filter((variant): variant is Variant => variant !== null),
-      })),
+              return matchingVariant || null;
+            })
+            .filter((variant): variant is Variant => variant !== null);
+
+          return {
+            type: ComponentTypeEnum.EntryReplacement,
+            baseline: component.baseline,
+            variants: processedVariants,
+          };
+        } else {
+          const inlineComponent = component;
+          return {
+            type: ComponentTypeEnum.InlineVariable,
+            baseline: inlineComponent.baseline,
+            key: inlineComponent.key,
+            valueType: inlineComponent.valueType,
+            variants: inlineComponent.variants,
+          };
+        }
+      }),
     };
   }
 

--- a/packages/utils/javascript/src/types/Config.ts
+++ b/packages/utils/javascript/src/types/Config.ts
@@ -1,26 +1,85 @@
 import { Baseline, VariantRef } from '@ninetailed/experience.js';
+import { SerializableObject } from '@ninetailed/experience.js-shared';
 
 import { z } from 'zod';
+
+export enum ComponentTypeEnum {
+  EntryReplacement = 'EntryReplacement',
+  InlineVariable = 'InlineVariable',
+}
+
+export enum InlineVariableComponentValueTypeEnum {
+  String = 'String',
+  Object = 'Object',
+}
+
+export const entryReplacementVariantSchema = z.object({
+  id: z.string(),
+  hidden: z.boolean().default(false),
+});
+
+export const variableVariantSchema = z.object({
+  value: z.union([z.string(), SerializableObject]),
+});
+
+export const EntryReplacementComponentSchema = z.object({
+  type: z.literal(ComponentTypeEnum.EntryReplacement).optional(), // [components-migration] TODO: to become mandatory once migration is finalized
+  baseline: entryReplacementVariantSchema,
+  variants: z.array(entryReplacementVariantSchema),
+});
+
+export type EntryReplacementComponent = z.infer<
+  typeof EntryReplacementComponentSchema
+>;
+
+export type TExperienceConfigComponentSchema = z.infer<
+  typeof ExperienceConfigComponentSchema
+>;
+
+export function isEntryReplacementComponent(
+  component: TExperienceConfigComponentSchema
+): component is EntryReplacementComponent {
+  return (
+    component.type === ComponentTypeEnum.EntryReplacement ||
+    component.type === undefined
+  );
+}
+
+export const InlineVariableComponentSchema = z.object({
+  type: z.literal(ComponentTypeEnum.InlineVariable),
+  key: z.string(),
+  valueType: z.nativeEnum(InlineVariableComponentValueTypeEnum),
+  baseline: variableVariantSchema,
+  variants: z.array(variableVariantSchema),
+});
+
+export type InlineVariableComponent = z.infer<
+  typeof InlineVariableComponentSchema
+>;
+
+export function isInlineVariableComponent(
+  component: TExperienceConfigComponentSchema
+): component is InlineVariableComponent {
+  return component.type === ComponentTypeEnum.InlineVariable;
+}
+export const ExperienceConfigComponentSchema = z.discriminatedUnion('type', [
+  EntryReplacementComponentSchema,
+  InlineVariableComponentSchema,
+]);
 
 export const Config = z.object({
   distribution: z.array(z.number()).optional().default([0.5, 0.5]),
   traffic: z.number().optional().default(0),
   components: z
-    .array(
-      z.object({
-        baseline: z.object({
-          id: z.string().default(''),
-        }),
-        variants: z.array(
-          z.object({
-            id: z.string().default(''),
-            hidden: z.boolean().default(false),
-          })
-        ),
-      })
-    )
+    .array(ExperienceConfigComponentSchema)
     .optional()
-    .default([{ baseline: { id: '' }, variants: [{ id: '', hidden: false }] }]),
+    .default([
+      {
+        type: ComponentTypeEnum.EntryReplacement,
+        baseline: { id: '' },
+        variants: [{ id: '' }],
+      },
+    ]),
   sticky: z.boolean().optional().default(false),
 });
 


### PR DESCRIPTION
Refactor component type definitions to support both entry replacement and inline variables.

With the changes of how the ExperienceConfiguration is typed, i had to change things in many places to make the PR pass all checks