### PR TITLE
Fix custom flags bug

### DIFF
--- a/packages/utils/contentful/src/types/__snapshots__/ExperienceEntry.spec.ts.snap
+++ b/packages/utils/contentful/src/types/__snapshots__/ExperienceEntry.spec.ts.snap
@@ -11,6 +11,7 @@ Object {
             "hidden": false,
             "id": "50LFM6YHR9NoqPilYKEGeT",
           },
+          "type": "EntryReplacement",
           "variants": Array [
             Object {
               "hidden": false,


### PR DESCRIPTION
- Resolved "Maximum update depth exceeded" warning caused by re-renders from un-memoized defaultValue in the useFlag hook.
- Optimized the useFlag hook to use deep equality checks internally to avoid unnecessary resets and re-renders — even when defaultValue is passed as a fresh object.
- started using preprocessor for the components to make sure any component would have a type field.