### PR TITLE
Nt 943 enable sdk to send component view events

### DIFF
--- a/packages/playgrounds/easy-hr/components/Variable/Variable.tsx
+++ b/packages/playgrounds/easy-hr/components/Variable/Variable.tsx
@@ -2,11 +2,37 @@ import { useFlag } from '@ninetailed/experience.js-react';
 import React from 'react';
 
 export const Variable: React.FC = () => {
-  const { value, status } = useFlag('colors', 'default');
+  const shouldTrack = () => {
+    // we can use this to conditionally track the variable
+    // e.g. based on user state, feature flags, etc.
+    return true;
+  };
+  const { value, status } = useFlag<{
+    padding: string;
+    color: string;
+  }>(
+    'testing-component-tracking',
+    {
+      padding: '10px',
+      color: 'blue',
+    },
+    shouldTrack
+  );
 
   // If still loading, return fallback
   if (status === 'loading') return <>{'fallback'}</>;
 
   // Otherwise, render the value directly
-  return <>{JSON.stringify(value)}</>;
+  return (
+    <>
+      <h1
+        style={{
+          padding: value.padding,
+          color: value.color,
+        }}
+      >
+        Variable Component
+      </h1>
+    </>
+  );
 };

--- a/packages/playgrounds/easy-hr/components/Variable/Variable.tsx
+++ b/packages/playgrounds/easy-hr/components/Variable/Variable.tsx
@@ -16,7 +16,9 @@ export const Variable: React.FC = () => {
       padding: '10px',
       color: 'blue',
     },
-    shouldTrack
+    {
+      shouldTrack,
+    }
   );
 
   // If still loading, return fallback

--- a/packages/plugins/analytics/src/index.ts
+++ b/packages/plugins/analytics/src/index.ts
@@ -1,11 +1,18 @@
 export {
   NinetailedAnalyticsPlugin,
   type SanitizedElementSeenPayload,
+  type SanitizedVariableSeenPayload,
 } from './lib/NinetailedAnalyticsPlugin';
 export type { Template } from './lib/NinetailedAnalyticsPlugin';
 
-export { ElementSeenPayloadSchema } from './lib/ElementSeenPayload';
-export type { ElementSeenPayload } from './lib/ElementSeenPayload';
+export {
+  ElementSeenPayloadSchema,
+  VariableSeenPayloadSchema,
+} from './lib/ElementSeenPayload';
+export type {
+  ElementSeenPayload,
+  VariableSeenPayload,
+} from './lib/ElementSeenPayload';
 
 export { TrackComponentPropertiesSchema } from './lib/TrackingProperties';
 export type { TrackComponentProperties } from './lib/TrackingProperties';

--- a/packages/plugins/analytics/src/index.ts
+++ b/packages/plugins/analytics/src/index.ts
@@ -8,6 +8,7 @@ export type { Template } from './lib/NinetailedAnalyticsPlugin';
 export {
   ElementSeenPayloadSchema,
   VariableSeenPayloadSchema,
+  ComponentViewEventComponentType,
 } from './lib/ElementSeenPayload';
 export type {
   ElementSeenPayload,

--- a/packages/plugins/analytics/src/index.ts
+++ b/packages/plugins/analytics/src/index.ts
@@ -8,9 +8,9 @@ export type { Template } from './lib/NinetailedAnalyticsPlugin';
 export {
   ElementSeenPayloadSchema,
   VariableSeenPayloadSchema,
-  ComponentViewEventComponentType,
 } from './lib/ElementSeenPayload';
 export type {
+  ComponentViewEventComponentType,
   ElementSeenPayload,
   VariableSeenPayload,
 } from './lib/ElementSeenPayload';

--- a/packages/plugins/analytics/src/index.ts
+++ b/packages/plugins/analytics/src/index.ts
@@ -8,7 +8,6 @@ export type { Template } from './lib/NinetailedAnalyticsPlugin';
 export {
   ElementSeenPayloadSchema,
   VariableSeenPayloadSchema,
-  ComponentViewEventComponentType,
 } from './lib/ElementSeenPayload';
 export type {
   ElementSeenPayload,

--- a/packages/plugins/analytics/src/lib/ElementSeenPayload.ts
+++ b/packages/plugins/analytics/src/lib/ElementSeenPayload.ts
@@ -1,17 +1,13 @@
 import { SerializableObject } from '@ninetailed/experience.js-shared';
 import { z } from 'zod';
 
-export enum ComponentViewEventComponentType {
-  Entry = 'Entry',
-  Variable = 'Variable',
-}
+export type ComponentViewEventComponentType = 'Entry' | 'Variable';
 
 // Base schema with shared properties
 const BaseSeenPayloadSchema = z.object({
-  componentType: z.nativeEnum(ComponentViewEventComponentType),
+  componentType: z.union([z.literal('Entry'), z.literal('Variable')]),
   variant: z.object({ id: z.string() }).catchall(z.unknown()),
   variantIndex: z.number(),
-  seenFor: z.number().optional().default(0),
 });
 
 // Element specific schema
@@ -44,6 +40,7 @@ export const ElementSeenPayloadSchema = BaseSeenPayloadSchema.extend({
       description:
         'This is the default all visitors audience as no audience was set.',
     }),
+  seenFor: z.number().optional().default(0),
 });
 
 export type ElementSeenPayload = Omit<

--- a/packages/plugins/analytics/src/lib/ElementSeenPayload.ts
+++ b/packages/plugins/analytics/src/lib/ElementSeenPayload.ts
@@ -1,12 +1,14 @@
-import {
-  ComponentTypeEnum,
-  SerializableObject,
-} from '@ninetailed/experience.js-shared';
+import { SerializableObject } from '@ninetailed/experience.js-shared';
 import { z } from 'zod';
+
+export enum ComponentViewEventComponentType {
+  Entry = 'Entry',
+  Variable = 'Variable',
+}
 
 // Base schema with shared properties
 const BaseSeenPayloadSchema = z.object({
-  componentType: z.nativeEnum(ComponentTypeEnum),
+  componentType: z.nativeEnum(ComponentViewEventComponentType),
   variant: z.object({ id: z.string() }).catchall(z.unknown()),
   variantIndex: z.number(),
   seenFor: z.number().optional().default(0),

--- a/packages/plugins/analytics/src/lib/ElementSeenPayload.ts
+++ b/packages/plugins/analytics/src/lib/ElementSeenPayload.ts
@@ -1,6 +1,19 @@
+import {
+  ComponentTypeEnum,
+  SerializableObject,
+} from '@ninetailed/experience.js-shared';
 import { z } from 'zod';
 
-export const ElementSeenPayloadSchema = z.object({
+// Base schema with shared properties
+const BaseSeenPayloadSchema = z.object({
+  componentType: z.nativeEnum(ComponentTypeEnum),
+  variant: z.object({ id: z.string() }).catchall(z.unknown()),
+  variantIndex: z.number(),
+  seenFor: z.number().optional().default(0),
+});
+
+// Element specific schema
+export const ElementSeenPayloadSchema = BaseSeenPayloadSchema.extend({
   element: z.any(),
   experience: z
     .object({
@@ -29,12 +42,17 @@ export const ElementSeenPayloadSchema = z.object({
       description:
         'This is the default all visitors audience as no audience was set.',
     }),
-  variant: z.object({ id: z.string() }).catchall(z.unknown()),
-  variantIndex: z.number(),
-  seenFor: z.number().optional().default(0),
 });
 
 export type ElementSeenPayload = Omit<
   z.input<typeof ElementSeenPayloadSchema>,
   'element'
 > & { element: Element };
+
+// Variable specific schema
+export const VariableSeenPayloadSchema = BaseSeenPayloadSchema.extend({
+  variable: SerializableObject,
+  experienceId: z.string().optional(),
+});
+
+export type VariableSeenPayload = z.input<typeof VariableSeenPayloadSchema>;

--- a/packages/plugins/analytics/src/lib/NinetailedAnalyticsPlugin.spec.ts
+++ b/packages/plugins/analytics/src/lib/NinetailedAnalyticsPlugin.spec.ts
@@ -1,7 +1,10 @@
 import { Analytics } from 'analytics';
 import { generateMock } from '@anatine/zod-mock';
 import { setTimeout as sleep } from 'node:timers/promises';
-import { ElementSeenPayloadSchema } from './ElementSeenPayload';
+import {
+  ComponentViewEventComponentType,
+  ElementSeenPayloadSchema,
+} from './ElementSeenPayload';
 import { Template } from './NinetailedAnalyticsPlugin';
 import { TestAnalyticsPlugin } from '../../test';
 import { AnalyticsInstance } from './AnalyticsInstance';
@@ -33,6 +36,7 @@ describe('NinetailedAnalyticsPlugin', () => {
     const mock = generateMock(ElementSeenPayloadSchema);
     return {
       ...mock,
+      componentType: ComponentViewEventComponentType.Entry,
       element: document.createElement('div'),
       seenFor: testAnalyticsPlugin.getComponentViewTrackingThreshold(),
       experience: { ...mock.experience, id: 'experience-1' },
@@ -60,6 +64,7 @@ describe('NinetailedAnalyticsPlugin', () => {
         {
           experience: data.experience,
           audience: data.audience,
+          componentType: ComponentViewEventComponentType.Entry,
           selectedVariant: data.variant,
           selectedVariantIndex: 1,
           selectedVariantSelector: 'variant 1',
@@ -134,6 +139,7 @@ describe('NinetailedAnalyticsPlugin', () => {
         {
           experience: data.experience,
           audience: data.audience,
+          componentType: data.componentType,
           selectedVariant: data.variant,
           selectedVariantIndex: 1,
           selectedVariantSelector: 'variant 1',
@@ -167,6 +173,7 @@ describe('NinetailedAnalyticsPlugin', () => {
           experience: data.experience,
           audience: data.audience,
           selectedVariant: data.variant,
+          componentType: data.componentType,
           selectedVariantIndex: 1,
           selectedVariantSelector: 'variant 1',
         },
@@ -198,6 +205,7 @@ describe('NinetailedAnalyticsPlugin', () => {
         {
           experience: data.experience,
           audience: data.audience,
+          componentType: data.componentType,
           selectedVariant: data.variant,
           selectedVariantIndex: 1,
           selectedVariantSelector: 'variant 1',
@@ -230,6 +238,7 @@ describe('NinetailedAnalyticsPlugin', () => {
         {
           experience: data.experience,
           audience: data.audience,
+          componentType: data.componentType,
           selectedVariant: data.variant,
           selectedVariantIndex: 1,
           selectedVariantSelector: 'variant 1',

--- a/packages/plugins/analytics/src/lib/NinetailedAnalyticsPlugin.spec.ts
+++ b/packages/plugins/analytics/src/lib/NinetailedAnalyticsPlugin.spec.ts
@@ -1,10 +1,7 @@
 import { Analytics } from 'analytics';
 import { generateMock } from '@anatine/zod-mock';
 import { setTimeout as sleep } from 'node:timers/promises';
-import {
-  ComponentViewEventComponentType,
-  ElementSeenPayloadSchema,
-} from './ElementSeenPayload';
+import { ElementSeenPayloadSchema } from './ElementSeenPayload';
 import { Template } from './NinetailedAnalyticsPlugin';
 import { TestAnalyticsPlugin } from '../../test';
 import { AnalyticsInstance } from './AnalyticsInstance';
@@ -36,7 +33,7 @@ describe('NinetailedAnalyticsPlugin', () => {
     const mock = generateMock(ElementSeenPayloadSchema);
     return {
       ...mock,
-      componentType: ComponentViewEventComponentType.Entry,
+      componentType: 'Entry',
       element: document.createElement('div'),
       seenFor: testAnalyticsPlugin.getComponentViewTrackingThreshold(),
       experience: { ...mock.experience, id: 'experience-1' },
@@ -64,7 +61,7 @@ describe('NinetailedAnalyticsPlugin', () => {
         {
           experience: data.experience,
           audience: data.audience,
-          componentType: ComponentViewEventComponentType.Entry,
+          componentType: 'Entry',
           selectedVariant: data.variant,
           selectedVariantIndex: 1,
           selectedVariantSelector: 'variant 1',

--- a/packages/plugins/analytics/src/lib/NinetailedAnalyticsPlugin.ts
+++ b/packages/plugins/analytics/src/lib/NinetailedAnalyticsPlugin.ts
@@ -65,10 +65,6 @@ export abstract class NinetailedAnalyticsPlugin<
   private getHasSeenExperienceEventPayload = (
     data: SanitizedElementSeenPayload
   ) => {
-    console.log(
-      'Generating has seen experience event payload with data:',
-      data
-    );
     const event = Object.entries(
       this.hasSeenExperienceEventTemplate
     ).reduce<THasSeenExperienceEventTemplate>(
@@ -210,10 +206,6 @@ export abstract class NinetailedAnalyticsPlugin<
       ...variablePayloads,
       sanitizedTrackVariableProperties,
     ]);
-
-    // TODO: Would we need to track the variable view here?
-    // using this.onTrackExperience? since its probably an experience,
-    // but we would need to conform the payload to look like the onHasSeenElement
   };
 
   /**

--- a/packages/plugins/analytics/src/lib/NinetailedAnalyticsPlugin.ts
+++ b/packages/plugins/analytics/src/lib/NinetailedAnalyticsPlugin.ts
@@ -26,7 +26,7 @@ export type SanitizedElementSeenPayload = {
   selectedVariantSelector: string;
   selectedVariant: ElementSeenPayload['variant'];
   selectedVariantIndex: ElementSeenPayload['variantIndex'];
-  componentType: ElementSeenPayload['componentType'];
+  componentType: NonNullable<ElementSeenPayload['componentType']>;
 };
 
 export type SanitizedVariableSeenPayload = {
@@ -65,6 +65,10 @@ export abstract class NinetailedAnalyticsPlugin<
   private getHasSeenExperienceEventPayload = (
     data: SanitizedElementSeenPayload
   ) => {
+    console.log(
+      'Generating has seen experience event payload with data:',
+      data
+    );
     const event = Object.entries(
       this.hasSeenExperienceEventTemplate
     ).reduce<THasSeenExperienceEventTemplate>(

--- a/packages/plugins/analytics/src/lib/NinetailedPlugin.ts
+++ b/packages/plugins/analytics/src/lib/NinetailedPlugin.ts
@@ -2,8 +2,8 @@ import { AnalyticsPlugin } from 'analytics';
 
 import { AnalyticsInstance } from './AnalyticsInstance';
 import { HasComponentViewTrackingThreshold } from './types/interfaces/HasComponentViewTrackingThreshold';
-import { ElementSeenPayload } from './ElementSeenPayload';
-import { HAS_SEEN_ELEMENT } from './constants';
+import { ElementSeenPayload, VariableSeenPayload } from './ElementSeenPayload';
+import { HAS_SEEN_ELEMENT, HAS_SEEN_VARIABLE } from './constants';
 
 export type EventHandlerParams<T = unknown> = {
   payload: T;
@@ -29,8 +29,19 @@ export abstract class NinetailedPlugin
     this.onHasSeenElement(event);
   };
 
+  public [HAS_SEEN_VARIABLE]: EventHandler<VariableSeenPayload> = (event) => {
+    // TODO: might need to also keep/remove this, but will need to ask someone which is prefered
+    if (event.payload.seenFor !== this.getComponentViewTrackingThreshold()) {
+      return;
+    }
+    this.onHasSeenVariable(event);
+  };
+
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   protected onHasSeenElement: EventHandler<ElementSeenPayload> = () => {};
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  protected onHasSeenVariable: EventHandler<VariableSeenPayload> = () => {};
 
   public setComponentViewTrackingThreshold = (threshold: number) => {
     this.componentViewTrackingThreshold = threshold;

--- a/packages/plugins/analytics/src/lib/NinetailedPlugin.ts
+++ b/packages/plugins/analytics/src/lib/NinetailedPlugin.ts
@@ -30,10 +30,6 @@ export abstract class NinetailedPlugin
   };
 
   public [HAS_SEEN_VARIABLE]: EventHandler<VariableSeenPayload> = (event) => {
-    // TODO: might need to also keep/remove this, but will need to ask someone which is prefered
-    if (event.payload.seenFor !== this.getComponentViewTrackingThreshold()) {
-      return;
-    }
     this.onHasSeenVariable(event);
   };
 

--- a/packages/plugins/analytics/src/lib/constants.ts
+++ b/packages/plugins/analytics/src/lib/constants.ts
@@ -2,3 +2,5 @@ export const HAS_SEEN_COMPONENT = 'has_seen_component';
 
 export const HAS_SEEN_ELEMENT_START = 'has_seen_elementStart';
 export const HAS_SEEN_ELEMENT = 'has_seen_element';
+
+export const HAS_SEEN_VARIABLE = 'has_seen_variable';

--- a/packages/plugins/analytics/test/fixtures.ts
+++ b/packages/plugins/analytics/test/fixtures.ts
@@ -1,3 +1,5 @@
+import { ComponentViewEventComponentType } from '../src/lib/ElementSeenPayload';
+
 export const TRACK_COMPONENT_PROPERTIES = {
   variant: {
     id: 'test',
@@ -25,5 +27,6 @@ export const TRACK_COMPONENT_VIEW_PROPERTIES = {
     id: 'test',
     test: 'test',
   },
+  componentType: ComponentViewEventComponentType.Entry,
   variantIndex: 1,
 };

--- a/packages/plugins/analytics/test/fixtures.ts
+++ b/packages/plugins/analytics/test/fixtures.ts
@@ -25,6 +25,6 @@ export const TRACK_COMPONENT_VIEW_PROPERTIES = {
     id: 'test',
     test: 'test',
   },
-  componentType: 'Entry',
+  componentType: 'Entry' as const,
   variantIndex: 1,
 };

--- a/packages/plugins/analytics/test/fixtures.ts
+++ b/packages/plugins/analytics/test/fixtures.ts
@@ -1,5 +1,3 @@
-import { ComponentViewEventComponentType } from '../src/lib/ElementSeenPayload';
-
 export const TRACK_COMPONENT_PROPERTIES = {
   variant: {
     id: 'test',
@@ -27,6 +25,6 @@ export const TRACK_COMPONENT_VIEW_PROPERTIES = {
     id: 'test',
     test: 'test',
   },
-  componentType: ComponentViewEventComponentType.Entry,
+  componentType: 'Entry',
   variantIndex: 1,
 };

--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
@@ -1,6 +1,9 @@
 import { setTimeout as sleep } from 'node:timers/promises';
 import { NinetailedApiClient } from '@ninetailed/experience.js-shared';
-import { NinetailedPlugin } from '@ninetailed/experience.js-plugin-analytics';
+import {
+  ComponentViewEventComponentType,
+  NinetailedPlugin,
+} from '@ninetailed/experience.js-plugin-analytics';
 import { Ninetailed } from '@ninetailed/experience.js';
 
 import { NinetailedInsightsPlugin } from './NinetailedInsightsPlugin';
@@ -62,6 +65,7 @@ describe('NinetailedInsightsPlugin', () => {
 
       ninetailed.observeElement({
         element,
+        componentType: ComponentViewEventComponentType.Entry,
         variant: { id: `variant-id-${i + 1}` },
         variantIndex: i,
       });
@@ -113,6 +117,7 @@ describe('NinetailedInsightsPlugin', () => {
 
       ninetailed.observeElement({
         element,
+        componentType: ComponentViewEventComponentType.Entry,
         variant: { id: `variant-id-${i + 1}` },
         variantIndex: i,
       });
@@ -147,6 +152,7 @@ describe('NinetailedInsightsPlugin', () => {
     for (let i = 0; i < 25; i++) {
       ninetailed.observeElement({
         element,
+        componentType: ComponentViewEventComponentType.Entry,
         variant: { id: `variant-id-${i + 1}` },
         variantIndex: i,
       });
@@ -181,6 +187,7 @@ describe('NinetailedInsightsPlugin', () => {
     for (let i = 0; i < 25; i++) {
       ninetailed.observeElement({
         element,
+        componentType: ComponentViewEventComponentType.Entry,
         variant: { id: `variant-id-1` },
         variantIndex: 0,
       });

--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
@@ -1,9 +1,6 @@
 import { setTimeout as sleep } from 'node:timers/promises';
 import { NinetailedApiClient } from '@ninetailed/experience.js-shared';
-import {
-  ComponentViewEventComponentType,
-  NinetailedPlugin,
-} from '@ninetailed/experience.js-plugin-analytics';
+import { NinetailedPlugin } from '@ninetailed/experience.js-plugin-analytics';
 import { Ninetailed } from '@ninetailed/experience.js';
 
 import { NinetailedInsightsPlugin } from './NinetailedInsightsPlugin';
@@ -65,7 +62,7 @@ describe('NinetailedInsightsPlugin', () => {
 
       ninetailed.observeElement({
         element,
-        componentType: ComponentViewEventComponentType.Entry,
+        componentType: 'Entry',
         variant: { id: `variant-id-${i + 1}` },
         variantIndex: i,
       });
@@ -117,7 +114,7 @@ describe('NinetailedInsightsPlugin', () => {
 
       ninetailed.observeElement({
         element,
-        componentType: ComponentViewEventComponentType.Entry,
+        componentType: 'Entry',
         variant: { id: `variant-id-${i + 1}` },
         variantIndex: i,
       });
@@ -152,7 +149,7 @@ describe('NinetailedInsightsPlugin', () => {
     for (let i = 0; i < 25; i++) {
       ninetailed.observeElement({
         element,
-        componentType: ComponentViewEventComponentType.Entry,
+        componentType: 'Entry',
         variant: { id: `variant-id-${i + 1}` },
         variantIndex: i,
       });
@@ -187,7 +184,7 @@ describe('NinetailedInsightsPlugin', () => {
     for (let i = 0; i < 25; i++) {
       ninetailed.observeElement({
         element,
-        componentType: ComponentViewEventComponentType.Entry,
+        componentType: 'Entry',
         variant: { id: `variant-id-1` },
         variantIndex: 0,
       });

--- a/packages/plugins/segment/src/NinetailedSegmentPlugin.spec.ts
+++ b/packages/plugins/segment/src/NinetailedSegmentPlugin.spec.ts
@@ -3,7 +3,6 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { AnalyticsBrowser } from '@segment/analytics-next';
 
 import { NinetailedSegmentPlugin } from './NinetailedSegmentPlugin';
-import { ComponentViewEventComponentType } from '@ninetailed/experience.js-plugin-analytics';
 
 type SetupArgs = {
   attachAnalyticsToWindow: boolean;
@@ -70,7 +69,7 @@ describe('NinetailedSegmentPlugin', () => {
         variant: {
           id: 'test-component',
         },
-        componentType: ComponentViewEventComponentType.Entry,
+        componentType: 'Entry',
         experience: {
           id: 'test-experience',
           type: 'nt_experiment',
@@ -133,7 +132,7 @@ describe('NinetailedSegmentPlugin', () => {
       await ninetailed.trackComponentView({
         element: {} as Element,
         variantIndex: 0,
-        componentType: ComponentViewEventComponentType.Entry,
+        componentType: 'Entry',
         variant: {
           id: 'test-component',
         },
@@ -199,7 +198,7 @@ describe('NinetailedSegmentPlugin', () => {
       await ninetailed.trackComponentView({
         element: {} as Element,
         variantIndex: 0,
-        componentType: ComponentViewEventComponentType.Entry,
+        componentType: 'Entry',
         variant: {
           id: 'test-component',
         },

--- a/packages/plugins/segment/src/NinetailedSegmentPlugin.spec.ts
+++ b/packages/plugins/segment/src/NinetailedSegmentPlugin.spec.ts
@@ -3,6 +3,7 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { AnalyticsBrowser } from '@segment/analytics-next';
 
 import { NinetailedSegmentPlugin } from './NinetailedSegmentPlugin';
+import { ComponentViewEventComponentType } from '@ninetailed/experience.js-plugin-analytics';
 
 type SetupArgs = {
   attachAnalyticsToWindow: boolean;
@@ -69,6 +70,7 @@ describe('NinetailedSegmentPlugin', () => {
         variant: {
           id: 'test-component',
         },
+        componentType: ComponentViewEventComponentType.Entry,
         experience: {
           id: 'test-experience',
           type: 'nt_experiment',
@@ -131,6 +133,7 @@ describe('NinetailedSegmentPlugin', () => {
       await ninetailed.trackComponentView({
         element: {} as Element,
         variantIndex: 0,
+        componentType: ComponentViewEventComponentType.Entry,
         variant: {
           id: 'test-component',
         },
@@ -196,6 +199,7 @@ describe('NinetailedSegmentPlugin', () => {
       await ninetailed.trackComponentView({
         element: {} as Element,
         variantIndex: 0,
+        componentType: ComponentViewEventComponentType.Entry,
         variant: {
           id: 'test-component',
         },

--- a/packages/sdks/javascript/src/index.ts
+++ b/packages/sdks/javascript/src/index.ts
@@ -11,6 +11,7 @@ export * from './lib/types/interfaces/RequiresEventBuilder';
 export * from './lib/types/interfaces/HasExperienceSelectionMiddleware';
 export * from './lib/types/interfaces/HasChangesModificationMiddleware';
 export * from './lib/types/interfaces/InterestedInSeenElements';
+export * from './lib/types/interfaces/InterestedInSeenVariables';
 export * from './lib/types/interfaces/InterestedInProfileChange';
 export * from './lib/types/interfaces/InterestedInHiddenPage';
 export * from './lib/types/interfaces/AcceptsCredentials';

--- a/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
@@ -3,7 +3,10 @@ import {
   FEATURES,
   NinetailedApiClient,
 } from '@ninetailed/experience.js-shared';
-import { NinetailedPlugin } from '@ninetailed/experience.js-plugin-analytics';
+import {
+  ComponentViewEventComponentType,
+  NinetailedPlugin,
+} from '@ninetailed/experience.js-plugin-analytics';
 import { TestAnalyticsPlugin } from '@ninetailed/experience.js-plugin-analytics/test';
 
 import { Ninetailed } from './Ninetailed';
@@ -264,6 +267,7 @@ describe('Ninetailed core class', () => {
         variant: { id: 'variant-id' },
         variantIndex: 1,
         experience,
+        componentType: ComponentViewEventComponentType.Entry,
       });
 
       // Simulate the intersection of the element with the viewport
@@ -300,6 +304,7 @@ describe('Ninetailed core class', () => {
         variant: { id: 'variant-1-id' },
         variantIndex: 1,
         experience,
+        componentType: ComponentViewEventComponentType.Entry,
       });
 
       ninetailed.observeElement({
@@ -307,6 +312,7 @@ describe('Ninetailed core class', () => {
         variant: { id: 'variant-2-id' },
         variantIndex: 2,
         experience,
+        componentType: ComponentViewEventComponentType.Entry,
       });
 
       intersect(element1, true);
@@ -349,6 +355,7 @@ describe('Ninetailed core class', () => {
         variant: { id: 'variant-1-id' },
         variantIndex: 1,
         experience,
+        componentType: ComponentViewEventComponentType.Entry,
       });
 
       ninetailed.observeElement({
@@ -356,6 +363,7 @@ describe('Ninetailed core class', () => {
         variant: { id: 'variant-2-id' },
         variantIndex: 2,
         experience,
+        componentType: ComponentViewEventComponentType.Entry,
       });
 
       intersect(element, true);
@@ -397,6 +405,7 @@ describe('Ninetailed core class', () => {
         variant: { id: 'variant-1-id' },
         variantIndex: 1,
         experience,
+        componentType: ComponentViewEventComponentType.Entry,
       });
 
       ninetailed.observeElement({
@@ -404,6 +413,7 @@ describe('Ninetailed core class', () => {
         variant: { id: 'variant-1-id' },
         variantIndex: 1,
         experience,
+        componentType: ComponentViewEventComponentType.Entry,
       });
 
       intersect(element, true);
@@ -434,6 +444,7 @@ describe('Ninetailed core class', () => {
         element,
         variant: { id: 'variant-id' },
         variantIndex: 1,
+        componentType: ComponentViewEventComponentType.Entry,
       });
 
       intersect(element, true);
@@ -461,6 +472,7 @@ describe('Ninetailed core class', () => {
         variant: { id: 'variant-id' },
         variantIndex: 1,
         experience,
+        componentType: ComponentViewEventComponentType.Entry,
       });
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
@@ -3,10 +3,7 @@ import {
   FEATURES,
   NinetailedApiClient,
 } from '@ninetailed/experience.js-shared';
-import {
-  ComponentViewEventComponentType,
-  NinetailedPlugin,
-} from '@ninetailed/experience.js-plugin-analytics';
+import { NinetailedPlugin } from '@ninetailed/experience.js-plugin-analytics';
 import { TestAnalyticsPlugin } from '@ninetailed/experience.js-plugin-analytics/test';
 
 import { Ninetailed } from './Ninetailed';
@@ -267,7 +264,7 @@ describe('Ninetailed core class', () => {
         variant: { id: 'variant-id' },
         variantIndex: 1,
         experience,
-        componentType: ComponentViewEventComponentType.Entry,
+        componentType: 'Entry',
       });
 
       // Simulate the intersection of the element with the viewport
@@ -304,7 +301,7 @@ describe('Ninetailed core class', () => {
         variant: { id: 'variant-1-id' },
         variantIndex: 1,
         experience,
-        componentType: ComponentViewEventComponentType.Entry,
+        componentType: 'Entry',
       });
 
       ninetailed.observeElement({
@@ -312,7 +309,7 @@ describe('Ninetailed core class', () => {
         variant: { id: 'variant-2-id' },
         variantIndex: 2,
         experience,
-        componentType: ComponentViewEventComponentType.Entry,
+        componentType: 'Entry',
       });
 
       intersect(element1, true);
@@ -355,7 +352,7 @@ describe('Ninetailed core class', () => {
         variant: { id: 'variant-1-id' },
         variantIndex: 1,
         experience,
-        componentType: ComponentViewEventComponentType.Entry,
+        componentType: 'Entry',
       });
 
       ninetailed.observeElement({
@@ -363,7 +360,7 @@ describe('Ninetailed core class', () => {
         variant: { id: 'variant-2-id' },
         variantIndex: 2,
         experience,
-        componentType: ComponentViewEventComponentType.Entry,
+        componentType: 'Entry',
       });
 
       intersect(element, true);
@@ -405,7 +402,7 @@ describe('Ninetailed core class', () => {
         variant: { id: 'variant-1-id' },
         variantIndex: 1,
         experience,
-        componentType: ComponentViewEventComponentType.Entry,
+        componentType: 'Entry',
       });
 
       ninetailed.observeElement({
@@ -413,7 +410,7 @@ describe('Ninetailed core class', () => {
         variant: { id: 'variant-1-id' },
         variantIndex: 1,
         experience,
-        componentType: ComponentViewEventComponentType.Entry,
+        componentType: 'Entry',
       });
 
       intersect(element, true);
@@ -444,7 +441,7 @@ describe('Ninetailed core class', () => {
         element,
         variant: { id: 'variant-id' },
         variantIndex: 1,
-        componentType: ComponentViewEventComponentType.Entry,
+        componentType: 'Entry',
       });
 
       intersect(element, true);
@@ -472,7 +469,7 @@ describe('Ninetailed core class', () => {
         variant: { id: 'variant-id' },
         variantIndex: 1,
         experience,
-        componentType: ComponentViewEventComponentType.Entry,
+        componentType: 'Entry',
       });
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/sdks/javascript/src/lib/Ninetailed.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.ts
@@ -23,6 +23,7 @@ import {
   isTrackEvent,
   isIdentifyEvent,
   isComponentViewEvent,
+  SerializableObject,
 } from '@ninetailed/experience.js-shared';
 
 import {
@@ -42,6 +43,7 @@ import {
   TrackHasSeenComponent,
   TrackComponentView,
   OnChangesChangeCallback,
+  TrackVariableComponentView,
 } from './types';
 import { PAGE_HIDDEN, HAS_SEEN_STICKY_COMPONENT } from './constants';
 import { ElementSeenObserver, ObserveOptions } from './ElementSeenObserver';
@@ -62,6 +64,7 @@ import {
   ElementSeenPayload,
   HAS_SEEN_COMPONENT,
   HAS_SEEN_ELEMENT,
+  HAS_SEEN_VARIABLE,
   HasComponentViewTrackingThreshold,
   NinetailedPlugin,
   hasComponentViewTrackingThreshold,
@@ -433,6 +436,20 @@ export class Ninetailed implements NinetailedInstance {
    */
   public trackHasSeenComponent: TrackHasSeenComponent = async (properties) => {
     return this.instance.dispatch({ ...properties, type: HAS_SEEN_COMPONENT });
+  };
+
+  public trackVariableComponentView: TrackVariableComponentView = (
+    properties
+  ) => {
+    console.log('===== trackVariableComponentView ====>', properties);
+    const validatedVariable = SerializableObject.parse(properties.variable);
+
+    return this.instance.dispatch({
+      ...properties,
+      type: HAS_SEEN_VARIABLE,
+      variable: validatedVariable,
+      seenFor: this.componentViewTrackingThreshold,
+    });
   };
 
   public trackComponentView: TrackComponentView = (properties) => {

--- a/packages/sdks/javascript/src/lib/Ninetailed.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.ts
@@ -441,14 +441,12 @@ export class Ninetailed implements NinetailedInstance {
   public trackVariableComponentView: TrackVariableComponentView = (
     properties
   ) => {
-    console.log('===== trackVariableComponentView ====>', properties);
     const validatedVariable = SerializableObject.parse(properties.variable);
 
     return this.instance.dispatch({
       ...properties,
       type: HAS_SEEN_VARIABLE,
       variable: validatedVariable,
-      seenFor: this.componentViewTrackingThreshold,
     });
   };
 

--- a/packages/sdks/javascript/src/lib/NinetailedCorePlugin/NinetailedCorePlugin.ts
+++ b/packages/sdks/javascript/src/lib/NinetailedCorePlugin/NinetailedCorePlugin.ts
@@ -257,6 +257,7 @@ export class NinetailedCorePlugin
         messageId: payload.meta.rid,
         timestamp: payload.meta.ts,
         componentId: payload.componentId,
+        componentType: payload.componentType,
         experienceId: payload.experienceId,
         variantIndex: payload.variantIndex,
         ctx,

--- a/packages/sdks/javascript/src/lib/NinetailedCorePlugin/actions.ts
+++ b/packages/sdks/javascript/src/lib/NinetailedCorePlugin/actions.ts
@@ -1,6 +1,7 @@
 import {
   HAS_SEEN_COMPONENT,
   HAS_SEEN_ELEMENT,
+  HAS_SEEN_VARIABLE,
 } from '@ninetailed/experience.js-plugin-analytics';
 import {
   PROFILE_CHANGE,
@@ -8,6 +9,7 @@ import {
   SelectedVariantInfo,
   PROFILE_RESET,
   Change,
+  SerializableObject,
 } from '@ninetailed/experience.js-shared';
 import { HAS_SEEN_STICKY_COMPONENT, PAGE_HIDDEN } from '../constants';
 
@@ -19,6 +21,12 @@ type HasSeenElementAction = {
   type: typeof HAS_SEEN_ELEMENT;
   seenFor: number | undefined;
   element: Element;
+};
+
+type HasSeenVariableAction = {
+  type: typeof HAS_SEEN_VARIABLE;
+  variable: SerializableObject;
+  seenFor: number | undefined;
 };
 
 type PageHiddenAction = {
@@ -66,6 +74,7 @@ export type DispatchAction =
   | ProfileResetAction
   | ProfileHasSeenStickyComponentAction
   | HasSeenElementAction
+  | HasSeenVariableAction
   | ProfileHasSeenComponentAction
   | PageHiddenAction;
 

--- a/packages/sdks/javascript/src/lib/NinetailedCorePlugin/actions.ts
+++ b/packages/sdks/javascript/src/lib/NinetailedCorePlugin/actions.ts
@@ -26,7 +26,6 @@ type HasSeenElementAction = {
 type HasSeenVariableAction = {
   type: typeof HAS_SEEN_VARIABLE;
   variable: SerializableObject;
-  seenFor: number | undefined;
 };
 
 type PageHiddenAction = {

--- a/packages/sdks/javascript/src/lib/types/index.ts
+++ b/packages/sdks/javascript/src/lib/types/index.ts
@@ -105,7 +105,7 @@ export type TrackComponentView = (
 ) => Promise<void>;
 
 export type TrackVariableComponentView = (
-  properties: Omit<VariableSeenPayload, 'seenFor'>
+  properties: VariableSeenPayload
 ) => Promise<void>;
 
 export type Identify = (

--- a/packages/sdks/javascript/src/lib/types/index.ts
+++ b/packages/sdks/javascript/src/lib/types/index.ts
@@ -12,6 +12,7 @@ import {
 } from '@ninetailed/experience.js-shared';
 import {
   ElementSeenPayload,
+  VariableSeenPayload,
   NinetailedPlugin,
   TrackComponentProperties,
 } from '@ninetailed/experience.js-plugin-analytics';
@@ -103,6 +104,10 @@ export type TrackComponentView = (
   properties: Omit<ElementSeenPayload, 'seenFor'>
 ) => Promise<void>;
 
+export type TrackVariableComponentView = (
+  properties: Omit<VariableSeenPayload, 'seenFor'>
+) => Promise<void>;
+
 export type Identify = (
   uid: string,
   traits?: Traits,
@@ -133,6 +138,7 @@ export interface NinetailedInstance<
    */
   trackHasSeenComponent: TrackHasSeenComponent;
   trackComponentView: TrackComponentView;
+  trackVariableComponentView: TrackVariableComponentView;
   identify: Identify;
   batch: Batch;
   reset: Reset;

--- a/packages/sdks/javascript/src/lib/types/interfaces/InterestedInSeenVariables.ts
+++ b/packages/sdks/javascript/src/lib/types/interfaces/InterestedInSeenVariables.ts
@@ -1,0 +1,9 @@
+import {
+  EventHandler,
+  VariableSeenPayload,
+  HAS_SEEN_VARIABLE,
+} from '@ninetailed/experience.js-plugin-analytics';
+
+export interface InterestedInSeenVariables {
+  [HAS_SEEN_VARIABLE]: EventHandler<VariableSeenPayload>;
+}

--- a/packages/sdks/javascript/src/lib/utils/EventBuilder.ts
+++ b/packages/sdks/javascript/src/lib/utils/EventBuilder.ts
@@ -70,6 +70,7 @@ export class EventBuilder {
 
   public component(
     componentId: string,
+    componentType: string,
     experienceId?: string,
     variantIndex?: number,
     data?: ComponentData
@@ -77,6 +78,7 @@ export class EventBuilder {
     return buildComponentViewEvent({
       ...this.buildEventBase(data),
       componentId,
+      componentType: componentType || 'Entry',
       experienceId: experienceId || '',
       variantIndex: variantIndex || 0,
     });

--- a/packages/sdks/javascript/src/lib/utils/EventBuilder.ts
+++ b/packages/sdks/javascript/src/lib/utils/EventBuilder.ts
@@ -11,7 +11,7 @@ import {
 } from '@ninetailed/experience.js-shared';
 import { v4 as uuid } from 'uuid';
 import { buildClientNinetailedRequestContext } from '../NinetailedCorePlugin';
-import { ComponentViewEventComponentType } from '@ninetailed/experience.js-plugin-analytics';
+import type { ComponentViewEventComponentType } from '@ninetailed/experience.js-plugin-analytics';
 
 type PageData = Partial<Omit<BuildPageEventArgs, 'ctx' | 'properties'>>;
 type TrackData = Partial<

--- a/packages/sdks/javascript/src/lib/utils/EventBuilder.ts
+++ b/packages/sdks/javascript/src/lib/utils/EventBuilder.ts
@@ -11,6 +11,7 @@ import {
 } from '@ninetailed/experience.js-shared';
 import { v4 as uuid } from 'uuid';
 import { buildClientNinetailedRequestContext } from '../NinetailedCorePlugin';
+import { ComponentViewEventComponentType } from '@ninetailed/experience.js-plugin-analytics';
 
 type PageData = Partial<Omit<BuildPageEventArgs, 'ctx' | 'properties'>>;
 type TrackData = Partial<
@@ -70,7 +71,7 @@ export class EventBuilder {
 
   public component(
     componentId: string,
-    componentType: string,
+    componentType: ComponentViewEventComponentType,
     experienceId?: string,
     variantIndex?: number,
     data?: ComponentData

--- a/packages/sdks/react/src/lib/Experience/Experience.tsx
+++ b/packages/sdks/react/src/lib/Experience/Experience.tsx
@@ -9,7 +9,6 @@ import {
 import { useExperience } from './useExperience';
 import { useNinetailed } from '../useNinetailed';
 import { ComponentMarker } from './ComponentMarker';
-import { ComponentViewEventComponentType } from '@ninetailed/experience.js-plugin-analytics';
 
 export type ExperienceComponent<P> = React.ComponentType<
   Omit<P, 'id'> & {
@@ -168,7 +167,7 @@ export const Experience = <
       observeElement({
         element: componentElement,
         experience,
-        componentType: ComponentViewEventComponentType.Entry,
+        componentType: 'Entry',
         audience,
         variant: isVariantHidden
           ? { ...variant, id: `${baseline.id}-hidden` }

--- a/packages/sdks/react/src/lib/Experience/Experience.tsx
+++ b/packages/sdks/react/src/lib/Experience/Experience.tsx
@@ -9,7 +9,7 @@ import {
 import { useExperience } from './useExperience';
 import { useNinetailed } from '../useNinetailed';
 import { ComponentMarker } from './ComponentMarker';
-import { ComponentTypeEnum } from '@ninetailed/experience.js-shared';
+import { ComponentViewEventComponentType } from '@ninetailed/experience.js-plugin-analytics';
 
 export type ExperienceComponent<P> = React.ComponentType<
   Omit<P, 'id'> & {
@@ -168,7 +168,7 @@ export const Experience = <
       observeElement({
         element: componentElement,
         experience,
-        componentType: ComponentTypeEnum.Entry,
+        componentType: ComponentViewEventComponentType.Entry,
         audience,
         variant: isVariantHidden
           ? { ...variant, id: `${baseline.id}-hidden` }

--- a/packages/sdks/react/src/lib/Experience/Experience.tsx
+++ b/packages/sdks/react/src/lib/Experience/Experience.tsx
@@ -9,6 +9,7 @@ import {
 import { useExperience } from './useExperience';
 import { useNinetailed } from '../useNinetailed';
 import { ComponentMarker } from './ComponentMarker';
+import { ComponentTypeEnum } from '@ninetailed/experience.js-shared';
 
 export type ExperienceComponent<P> = React.ComponentType<
   Omit<P, 'id'> & {
@@ -167,6 +168,7 @@ export const Experience = <
       observeElement({
         element: componentElement,
         experience,
+        componentType: ComponentTypeEnum.Entry,
         audience,
         variant: isVariantHidden
           ? { ...variant, id: `${baseline.id}-hidden` }

--- a/packages/sdks/react/src/lib/useFlag.ts
+++ b/packages/sdks/react/src/lib/useFlag.ts
@@ -6,7 +6,6 @@ import {
 import { ChangesState } from '@ninetailed/experience.js';
 import { isEqual } from 'radash';
 import { useNinetailed } from './useNinetailed';
-import { ComponentViewEventComponentType } from '@ninetailed/experience.js-plugin-analytics';
 
 export type FlagResult<T> =
   | { status: 'loading'; value: T; error: null }
@@ -115,7 +114,7 @@ export function useFlag<T extends AllowedVariableType>(
             ninetailed.trackVariableComponentView({
               variable: change.value,
               variant: { id: `Variable-${key}` },
-              componentType: ComponentViewEventComponentType.Variable,
+              componentType: 'Entry',
               variantIndex: change.meta.variantIndex,
               experienceId: change.meta.experienceId,
             });

--- a/packages/sdks/react/src/lib/useFlag.ts
+++ b/packages/sdks/react/src/lib/useFlag.ts
@@ -137,7 +137,6 @@ export function useFlag<T extends AllowedVariableType>(
     });
 
     return unsubscribe;
-    // TODO: Should we have shouldTrackHook as a dependency? i think it should not change often unless the user changes the tracking logic
   }, [ninetailed]);
 
   return result;

--- a/packages/sdks/shared/src/lib/event/build-component-view-event.ts
+++ b/packages/sdks/shared/src/lib/event/build-component-view-event.ts
@@ -8,6 +8,7 @@ export type BuildComponentViewEventData = Object.Omit<
     BuildEventArgs,
     {
       componentId: string;
+      componentType: string;
       experienceId?: string;
       variantIndex?: number;
     },
@@ -21,6 +22,7 @@ export const buildComponentViewEvent = (
 ): ComponentViewEvent => {
   return {
     ...buildEvent({ ...data, type: 'component' }),
+    componentType: data.componentType,
     componentId: data.componentId,
     experienceId: data.experienceId,
     variantIndex: data.variantIndex,

--- a/packages/sdks/shared/src/lib/event/build-component-view-event.ts
+++ b/packages/sdks/shared/src/lib/event/build-component-view-event.ts
@@ -1,8 +1,8 @@
 import { Object } from 'ts-toolbelt';
 
-import {
+import type {
   ComponentViewEventComponentType,
-  type ComponentViewEvent,
+  ComponentViewEvent,
 } from '../types/Event/ComponentViewEvent';
 import { type BuildEventArgs, buildEvent } from './build-event';
 

--- a/packages/sdks/shared/src/lib/event/build-component-view-event.ts
+++ b/packages/sdks/shared/src/lib/event/build-component-view-event.ts
@@ -1,6 +1,9 @@
 import { Object } from 'ts-toolbelt';
 
-import { type ComponentViewEvent } from '../types/Event/ComponentViewEvent';
+import {
+  ComponentViewEventComponentType,
+  type ComponentViewEvent,
+} from '../types/Event/ComponentViewEvent';
 import { type BuildEventArgs, buildEvent } from './build-event';
 
 export type BuildComponentViewEventData = Object.Omit<
@@ -8,7 +11,7 @@ export type BuildComponentViewEventData = Object.Omit<
     BuildEventArgs,
     {
       componentId: string;
-      componentType: string;
+      componentType: ComponentViewEventComponentType;
       experienceId?: string;
       variantIndex?: number;
     },

--- a/packages/sdks/shared/src/lib/types/Event/ComponentViewEvent.ts
+++ b/packages/sdks/shared/src/lib/types/Event/ComponentViewEvent.ts
@@ -5,6 +5,7 @@ export type ComponentViewEvent = Object.Merge<
   SharedEventProperties,
   {
     type: 'component';
+    componentType: string;
     componentId: string;
     experienceId?: string;
     variantIndex?: number;

--- a/packages/sdks/shared/src/lib/types/Event/ComponentViewEvent.ts
+++ b/packages/sdks/shared/src/lib/types/Event/ComponentViewEvent.ts
@@ -1,11 +1,14 @@
 import { Object } from 'ts-toolbelt';
 import { type SharedEventProperties } from './SharedEventProperties';
 
+// Adding this here to avoid circular dependency
+export type ComponentViewEventComponentType = 'Entry' | 'Variable';
+
 export type ComponentViewEvent = Object.Merge<
   SharedEventProperties,
   {
     type: 'component';
-    componentType: string;
+    componentType: ComponentViewEventComponentType;
     componentId: string;
     experienceId?: string;
     variantIndex?: number;

--- a/packages/sdks/shared/src/lib/types/ExperienceDefinition/BaselineWithVariants.ts
+++ b/packages/sdks/shared/src/lib/types/ExperienceDefinition/BaselineWithVariants.ts
@@ -4,8 +4,8 @@ import { Reference } from './Reference';
 import { VariantRef } from './VariantRef';
 
 export enum ComponentTypeEnum {
-  Entry = 'Entry',
-  Variable = 'Variable',
+  EntryReplacement = 'EntryReplacement',
+  InlineVariable = 'InlineVariable',
 }
 
 enum InlineVariableComponentValueTypeEnum {
@@ -14,13 +14,13 @@ enum InlineVariableComponentValueTypeEnum {
 }
 
 export type EntryReplacement<Variant extends Reference> = {
-  type: ComponentTypeEnum.Entry;
+  type: ComponentTypeEnum.EntryReplacement;
   baseline: Baseline;
   variants: (Variant | VariantRef)[];
 };
 
 export type InlineVariable = {
-  type: ComponentTypeEnum.Variable;
+  type: ComponentTypeEnum.InlineVariable;
   key: string;
   valueType: InlineVariableComponentValueTypeEnum;
   baseline: { value: string | SerializableObject };

--- a/packages/sdks/shared/src/lib/types/ExperienceDefinition/BaselineWithVariants.ts
+++ b/packages/sdks/shared/src/lib/types/ExperienceDefinition/BaselineWithVariants.ts
@@ -4,8 +4,8 @@ import { Reference } from './Reference';
 import { VariantRef } from './VariantRef';
 
 export enum ComponentTypeEnum {
-  EntryReplacement = 'EntryReplacement',
-  InlineVariable = 'InlineVariable',
+  Entry = 'Entry',
+  Variable = 'Variable',
 }
 
 enum InlineVariableComponentValueTypeEnum {
@@ -14,13 +14,13 @@ enum InlineVariableComponentValueTypeEnum {
 }
 
 export type EntryReplacement<Variant extends Reference> = {
-  type: ComponentTypeEnum.EntryReplacement;
+  type: ComponentTypeEnum.Entry;
   baseline: Baseline;
   variants: (Variant | VariantRef)[];
 };
 
 export type InlineVariable = {
-  type: ComponentTypeEnum.InlineVariable;
+  type: ComponentTypeEnum.Variable;
   key: string;
   valueType: InlineVariableComponentValueTypeEnum;
   baseline: { value: string | SerializableObject };

--- a/packages/tests/javascript-integration/src/lib/analytics-pipeline.spec.ts
+++ b/packages/tests/javascript-integration/src/lib/analytics-pipeline.spec.ts
@@ -3,7 +3,6 @@ import { TestAnalyticsPlugin } from '@ninetailed/experience.js-plugin-analytics/
 import { Ninetailed } from '@ninetailed/experience.js';
 import { setTimeout as sleep } from 'node:timers/promises';
 import {
-  ComponentViewEventComponentType,
   ElementSeenPayloadSchema,
   TrackComponentPropertiesSchema,
 } from '@ninetailed/experience.js-plugin-analytics';
@@ -28,7 +27,7 @@ describe('Analytics pipeline', () => {
   it('Should be able to send track experience events which will be received from the TestAnalyticsPlugin', async () => {
     const data = {
       ...generateMock(ElementSeenPayloadSchema),
-      componentType: ComponentViewEventComponentType.Entry,
+      componentType: 'Entry' as const,
       element: document.createElement('div'),
       variantIndex: 1,
     };

--- a/packages/tests/javascript-integration/src/lib/analytics-pipeline.spec.ts
+++ b/packages/tests/javascript-integration/src/lib/analytics-pipeline.spec.ts
@@ -3,6 +3,7 @@ import { TestAnalyticsPlugin } from '@ninetailed/experience.js-plugin-analytics/
 import { Ninetailed } from '@ninetailed/experience.js';
 import { setTimeout as sleep } from 'node:timers/promises';
 import {
+  ComponentViewEventComponentType,
   ElementSeenPayloadSchema,
   TrackComponentPropertiesSchema,
 } from '@ninetailed/experience.js-plugin-analytics';
@@ -27,6 +28,7 @@ describe('Analytics pipeline', () => {
   it('Should be able to send track experience events which will be received from the TestAnalyticsPlugin', async () => {
     const data = {
       ...generateMock(ElementSeenPayloadSchema),
+      componentType: ComponentViewEventComponentType.Entry,
       element: document.createElement('div'),
       variantIndex: 1,
     };
@@ -39,6 +41,7 @@ describe('Analytics pipeline', () => {
       {
         experience: data.experience,
         audience: data.audience,
+        componentType: data.componentType,
         selectedVariant: data.variant,
         selectedVariantIndex: data.variantIndex,
         selectedVariantSelector: 'variant 1',

--- a/packages/tests/javascript-integration/src/lib/multiple-analytics-plugins.spec.ts
+++ b/packages/tests/javascript-integration/src/lib/multiple-analytics-plugins.spec.ts
@@ -4,6 +4,7 @@ import { Ninetailed } from '@ninetailed/experience.js';
 import { NinetailedGoogleTagmanagerPlugin } from '@ninetailed/experience.js-plugin-google-tagmanager';
 import { NinetailedInsightsPlugin } from '@ninetailed/experience.js-plugin-insights';
 import { NinetailedSegmentPlugin } from '@ninetailed/experience.js-plugin-segment';
+import { ComponentViewEventComponentType } from '@ninetailed/experience.js-plugin-analytics';
 
 const setup = () => {
   const gtmPlugin = new NinetailedGoogleTagmanagerPlugin();
@@ -32,6 +33,7 @@ describe('A Ninetailed setup with multiple analytics plugins', () => {
         experience: { id: 'experience-1', name: 'test', type: 'nt_experiment' },
         variant: { id: 'variant-1', name: 'test' },
         audience: { id: 'audience-1', name: 'test' },
+        componentType: ComponentViewEventComponentType.Entry,
         element: document.createElement('div'),
         variantIndex: 1,
       });

--- a/packages/tests/javascript-integration/src/lib/multiple-analytics-plugins.spec.ts
+++ b/packages/tests/javascript-integration/src/lib/multiple-analytics-plugins.spec.ts
@@ -4,7 +4,6 @@ import { Ninetailed } from '@ninetailed/experience.js';
 import { NinetailedGoogleTagmanagerPlugin } from '@ninetailed/experience.js-plugin-google-tagmanager';
 import { NinetailedInsightsPlugin } from '@ninetailed/experience.js-plugin-insights';
 import { NinetailedSegmentPlugin } from '@ninetailed/experience.js-plugin-segment';
-import { ComponentViewEventComponentType } from '@ninetailed/experience.js-plugin-analytics';
 
 const setup = () => {
   const gtmPlugin = new NinetailedGoogleTagmanagerPlugin();
@@ -33,7 +32,7 @@ describe('A Ninetailed setup with multiple analytics plugins', () => {
         experience: { id: 'experience-1', name: 'test', type: 'nt_experiment' },
         variant: { id: 'variant-1', name: 'test' },
         audience: { id: 'audience-1', name: 'test' },
-        componentType: ComponentViewEventComponentType.Entry,
+        componentType: 'Entry',
         element: document.createElement('div'),
         variantIndex: 1,
       });


### PR DESCRIPTION
What I did in this PR:
- Implement the componentView tracking for custom flags to be sent through the SDK to our insights API.
- Found a minor issue when testing where it was mistakenly stored as `value: { value: {...} }`
- We added the componentType field to differentiate between different componentView events. 

**_Context: we have recently been getting some requests regarding the component tracking for custom flags and this is the PR that implements that._**

Diagram on how we are sending componentView events:
![image](https://github.com/user-attachments/assets/451a27b3-f373-4c76-bb79-8f333959ac94)
