### PR TITLE
fix: deprecate openExperienceAnalytics

### DIFF
--- a/packages/plugins/preview-bridge/src/PreviewPluginApi.ts
+++ b/packages/plugins/preview-bridge/src/PreviewPluginApi.ts
@@ -37,6 +37,9 @@ export type PreviewPluginApi = {
   experiences: ExperienceConfiguration[];
 
   openExperienceEditor?: (experience: ExperienceConfiguration) => void;
+  /**
+   * @deprecated Will be removed in a future release. Use `openExperienceEditor` instead to see the experience insights.
+   */
   openExperienceAnalytics: (experience: ExperienceConfiguration) => void;
   openAudienceEditor?: (audienceDefinition: ExposedAudienceDefinition) => void;
 };

--- a/packages/plugins/preview/src/lib/plugin/NinetailedPreviewPlugin.ts
+++ b/packages/plugins/preview/src/lib/plugin/NinetailedPreviewPlugin.ts
@@ -567,7 +567,13 @@ export class NinetailedPreviewPlugin
       return this.onOpenExperienceEditor(experience);
   }
 
+  /**
+   * @deprecated This method will be removed in a future release. Use `openExperienceEditor` instead to see the experience insights.
+   */
   public openExperienceAnalytics(experience: ExperienceConfiguration) {
+    logger.warn(
+      'The `openExperienceAnalytics` method is deprecated and will be removed in a future release. Use `openExperienceEditor` instead to see the experience insights.'
+    );
     window.open(
       `https://app.ninetailed.io/${this.clientId}/${this.environment}/experiences/${experience.id}`,
       '_blank'


### PR DESCRIPTION
We are deprecating `openExperienceAnalytics` because all the traffic should be directed to the Contentful entries for checking the insights. 

The analytics page that the `openExperienceAnalytics` method navigates to, is no longer active. We will remove this method completely in future releases. 