### PR TITLE
refactor: simplify useFlag hook and introduce useFlagWithManualTracki…

### DIFF
--- a/packages/sdks/react/src/lib/useFlag.ts
+++ b/packages/sdks/react/src/lib/useFlag.ts
@@ -1,11 +1,6 @@
-import { useEffect, useState, useRef } from 'react';
-import {
-  AllowedVariableType,
-  ChangeTypes,
-} from '@ninetailed/experience.js-shared';
-import { ChangesState } from '@ninetailed/experience.js';
-import { isEqual } from 'radash';
-import { useNinetailed } from './useNinetailed';
+import { useEffect } from 'react';
+import { AllowedVariableType } from '@ninetailed/experience.js-shared';
+import { useFlagWithManualTracking } from './useFlagWithManualTracking'; // <-- make sure to import the manual hook
 
 export type FlagResult<T> =
   | { status: 'loading'; value: T; error: null }
@@ -13,132 +8,30 @@ export type FlagResult<T> =
   | { status: 'error'; value: T; error: Error };
 
 type UseFlagOptions = {
-  shouldTrack?: boolean | (() => boolean);
+  shouldAutoTrack?: boolean | (() => boolean);
 };
 
 /**
- * Hook to access a Ninetailed variable flag with built-in tracking.
+ * Hook to access a Ninetailed variable flag with built-in auto-tracking.
+ * Internally reuses useFlagWithManualTracking.
  */
 export function useFlag<T extends AllowedVariableType>(
   flagKey: string,
   defaultValue: T,
   options: UseFlagOptions = {}
 ): FlagResult<T> {
-  const ninetailed = useNinetailed();
+  const [result, track] = useFlagWithManualTracking<T>(flagKey, defaultValue);
 
-  const lastProcessedState = useRef<ChangesState | null>(null);
-  const defaultValueRef = useRef<T>(defaultValue);
-  const flagKeyRef = useRef<string>(flagKey);
-
-  const [result, setResult] = useState<FlagResult<T>>({
-    value: defaultValue,
-    status: 'loading',
-    error: null,
-  });
-
-  // Reset on input change
   useEffect(() => {
-    if (
-      !isEqual(defaultValueRef.current, defaultValue) ||
-      flagKeyRef.current !== flagKey
-    ) {
-      defaultValueRef.current = defaultValue;
-      flagKeyRef.current = flagKey;
-      setResult({
-        value: defaultValue,
-        status: 'loading',
-        error: null,
-      });
-      lastProcessedState.current = null;
+    const shouldAutoTrack =
+      typeof options.shouldAutoTrack === 'function'
+        ? options.shouldAutoTrack()
+        : options.shouldAutoTrack !== false;
+
+    if (result.status === 'success' && shouldAutoTrack) {
+      track();
     }
-  }, [flagKey, defaultValue]);
-
-  // Track changes
-  useEffect(() => {
-    const unsubscribe = ninetailed.onChangesChange((changesState) => {
-      if (
-        lastProcessedState.current &&
-        isEqual(lastProcessedState.current, changesState)
-      ) {
-        return;
-      }
-
-      lastProcessedState.current = changesState;
-
-      if (changesState.status === 'loading') {
-        setResult({
-          value: defaultValueRef.current,
-          status: 'loading',
-          error: null,
-        });
-        return;
-      }
-
-      if (changesState.status === 'error') {
-        setResult({
-          value: defaultValueRef.current,
-          status: 'error',
-          error: changesState.error,
-        });
-        return;
-      }
-
-      try {
-        const change = changesState.changes.find(
-          (change) => change.key === flagKeyRef.current
-        );
-
-        if (change && change.type === ChangeTypes.Variable) {
-          const rawValue = change.value;
-
-          const actualValue =
-            rawValue &&
-            typeof rawValue === 'object' &&
-            rawValue !== null &&
-            'value' in rawValue &&
-            typeof (rawValue as Record<string, unknown>)['value'] === 'object'
-              ? (rawValue as Record<string, unknown>)['value']
-              : rawValue;
-
-          setResult({
-            value: actualValue as T,
-            status: 'success',
-            error: null,
-          });
-
-          const key = flagKeyRef.current;
-          const shouldTrack =
-            typeof options.shouldTrack === 'function'
-              ? options.shouldTrack()
-              : options.shouldTrack !== false;
-
-          if (shouldTrack) {
-            ninetailed.trackVariableComponentView({
-              variable: change.value,
-              variant: { id: `Variable-${key}` },
-              componentType: 'Variable',
-              variantIndex: change.meta.variantIndex,
-              experienceId: change.meta.experienceId,
-            });
-          }
-        } else {
-          setResult({
-            value: defaultValueRef.current,
-            status: 'success',
-            error: null,
-          });
-        }
-      } catch (error) {
-        setResult({
-          value: defaultValueRef.current,
-          status: 'error',
-          error: error instanceof Error ? error : new Error(String(error)),
-        });
-      }
-    });
-
-    return unsubscribe;
-  }, [ninetailed]);
+  }, [result.status, track, options.shouldAutoTrack]);
 
   return result;
 }

--- a/packages/sdks/react/src/lib/useFlagWithManualTracking.ts
+++ b/packages/sdks/react/src/lib/useFlagWithManualTracking.ts
@@ -1,0 +1,143 @@
+import {
+  AllowedVariableType,
+  Change,
+  ChangeTypes,
+} from '@ninetailed/experience.js-shared';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNinetailed } from './useNinetailed';
+import { ChangesState } from '@ninetailed/experience.js';
+import { isEqual } from 'radash';
+
+export type FlagResult<T> =
+  | { status: 'loading'; value: T; error: null }
+  | { status: 'success'; value: T; error: null }
+  | { status: 'error'; value: T; error: Error };
+
+export type FlagResultWithTracking<T> = [FlagResult<T>, () => void];
+
+type VariableChange = Extract<Change, { type: ChangeTypes.Variable }>;
+
+/**
+ * Hook to access a Ninetailed variable flag with manual tracking control.
+ */
+export function useFlagWithManualTracking<T extends AllowedVariableType>(
+  flagKey: string,
+  defaultValue: T
+): FlagResultWithTracking<T> {
+  const ninetailed = useNinetailed();
+
+  const flagKeyRef = useRef(flagKey);
+  const defaultValueRef = useRef(defaultValue);
+  const lastProcessedState = useRef<ChangesState | null>(null);
+  const changeRef = useRef<VariableChange | null>(null);
+
+  const [result, setResult] = useState<FlagResult<T>>({
+    value: defaultValue,
+    status: 'loading',
+    error: null,
+  });
+
+  // Reset if inputs change
+  useEffect(() => {
+    if (
+      !isEqual(defaultValueRef.current, defaultValue) ||
+      flagKeyRef.current !== flagKey
+    ) {
+      defaultValueRef.current = defaultValue;
+      flagKeyRef.current = flagKey;
+      lastProcessedState.current = null;
+      changeRef.current = null;
+
+      setResult({
+        value: defaultValue,
+        status: 'loading',
+        error: null,
+      });
+    }
+  }, [flagKey, defaultValue]);
+
+  // Listen for personalization state changes
+  useEffect(() => {
+    const unsubscribe = ninetailed.onChangesChange((changesState) => {
+      if (
+        lastProcessedState.current &&
+        isEqual(lastProcessedState.current, changesState)
+      ) {
+        return;
+      }
+
+      lastProcessedState.current = changesState;
+
+      if (changesState.status === 'loading') {
+        setResult({
+          value: defaultValueRef.current,
+          status: 'loading',
+          error: null,
+        });
+        return;
+      }
+
+      if (changesState.status === 'error') {
+        setResult({
+          value: defaultValueRef.current,
+          status: 'error',
+          error: changesState.error,
+        });
+        return;
+      }
+
+      // Find relevant change for this flag
+      const change = changesState.changes.find(
+        (c): c is VariableChange =>
+          c.key === flagKeyRef.current && c.type === ChangeTypes.Variable
+      );
+
+      if (change) {
+        changeRef.current = change;
+
+        const rawValue = change.value;
+
+        const actualValue =
+          rawValue &&
+          typeof rawValue === 'object' &&
+          rawValue !== null &&
+          'value' in rawValue &&
+          typeof (rawValue as Record<string, unknown>)['value'] === 'object'
+            ? (rawValue as Record<string, unknown>)['value']
+            : rawValue;
+
+        setResult({
+          value: actualValue as T,
+          status: 'success',
+          error: null,
+        });
+      } else {
+        changeRef.current = null;
+
+        setResult({
+          value: defaultValueRef.current,
+          status: 'success',
+          error: null,
+        });
+      }
+    });
+
+    return unsubscribe;
+  }, [ninetailed]);
+
+  // Manual tracking function
+  const track = useCallback(() => {
+    const change = changeRef.current;
+    if (!change) return;
+
+    ninetailed.trackVariableComponentView({
+      variable: change.value,
+      variant: { id: `Variable-${flagKeyRef.current}` },
+      componentType: 'Variable',
+      variantIndex: change.meta.variantIndex,
+      experienceId: change.meta.experienceId,
+    });
+  }, [ninetailed]);
+
+  return [result, track];
+}


### PR DESCRIPTION
### ✨ Changes

* Refactored `useFlag` to support **optional automatic tracking** via `shouldTrack`.
* Introduced a new hook: `useFlagWithManualTracking`, which returns a tuple of `[result, track]` for **manual control**.
* Ensures tracking only occurs **when the user is actually affected** by the flag (e.g., on interaction or in-view).
* Internally uses `useRef` and `useCallback` to maintain stability and prevent stale data access.

---

### 📚 Context

This change improves how custom flag views are tracked in alignment with **Performance Tracking** requirements — enabling tracking only after a user has actually seen or been affected by a flag variant (e.g., modal shown, CTA clicked).

Auto-tracking is still supported for globally visible flags (e.g., dark mode) via `{ shouldTrack: true }`, while manual tracking is now cleanly supported via `useFlagWithManualTracking`.

Huge thanks to @maroun9t for thinking of the solution and @SergeiSmekhunov for the support!
