### PR TITLE
Updating the validation/parser for Custom Flag tracking

### DIFF
--- a/packages/plugins/analytics/src/lib/ElementSeenPayload.ts
+++ b/packages/plugins/analytics/src/lib/ElementSeenPayload.ts
@@ -1,4 +1,4 @@
-import { SerializableObject } from '@ninetailed/experience.js-shared';
+import { allowVariableTypeSchema } from '@ninetailed/experience.js-shared';
 import { z } from 'zod';
 
 export type ComponentViewEventComponentType = 'Entry' | 'Variable';
@@ -50,7 +50,7 @@ export type ElementSeenPayload = Omit<
 
 // Variable specific schema
 export const VariableSeenPayloadSchema = BaseSeenPayloadSchema.extend({
-  variable: SerializableObject,
+  variable: allowVariableTypeSchema,
   experienceId: z.string().optional(),
 });
 

--- a/packages/sdks/javascript/src/lib/Ninetailed.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.ts
@@ -23,7 +23,7 @@ import {
   isTrackEvent,
   isIdentifyEvent,
   isComponentViewEvent,
-  SerializableObject,
+  allowVariableTypeSchema,
 } from '@ninetailed/experience.js-shared';
 
 import {
@@ -441,7 +441,9 @@ export class Ninetailed implements NinetailedInstance {
   public trackVariableComponentView: TrackVariableComponentView = (
     properties
   ) => {
-    const validatedVariable = SerializableObject.parse(properties.variable);
+    const validatedVariable = allowVariableTypeSchema.parse(
+      properties.variable
+    );
 
     return this.instance.dispatch({
       ...properties,

--- a/packages/sdks/javascript/src/lib/NinetailedCorePlugin/actions.ts
+++ b/packages/sdks/javascript/src/lib/NinetailedCorePlugin/actions.ts
@@ -9,7 +9,7 @@ import {
   SelectedVariantInfo,
   PROFILE_RESET,
   Change,
-  SerializableObject,
+  AllowedVariableType,
 } from '@ninetailed/experience.js-shared';
 import { HAS_SEEN_STICKY_COMPONENT, PAGE_HIDDEN } from '../constants';
 
@@ -25,7 +25,7 @@ type HasSeenElementAction = {
 
 type HasSeenVariableAction = {
   type: typeof HAS_SEEN_VARIABLE;
-  variable: SerializableObject;
+  variable: AllowedVariableType;
 };
 
 type PageHiddenAction = {


### PR DESCRIPTION
We've had some reports that some values our customers can enter for a custom flag entry, which are valid per documentation, fail validation when being used in the SDK. This PR attempts to change that issue by making the definition and validation of Variable entries more consistent. However, it needs to be verified whether this is correct, and whether anything needs to change on the back-end as well.