### PR TITLE
fix: improve variable overwrite comparison using isEqual from radash

### DIFF
--- a/packages/plugins/preview/package.json
+++ b/packages/plugins/preview/package.json
@@ -18,6 +18,7 @@
     "@ninetailed/experience.js-shared": "*",
     "@ninetailed/experience.js": "*",
     "@ninetailed/experience.js-preview-bridge": "*",
-    "@ninetailed/experience.js-plugin-analytics": "*"
+    "@ninetailed/experience.js-plugin-analytics": "*",
+    "radash": "10.9.0"
   }
 }

--- a/packages/plugins/preview/src/lib/plugin/NinetailedPreviewPlugin.ts
+++ b/packages/plugins/preview/src/lib/plugin/NinetailedPreviewPlugin.ts
@@ -35,6 +35,7 @@ import {
 } from '@ninetailed/experience.js-plugin-analytics';
 
 import { WidgetContainer, WidgetContainerOptions } from './WidgetContainer';
+import { isEqual } from 'radash';
 
 export const NINETAILED_PREVIEW_EVENTS = {
   previewAudiences: 'previewAudiences',
@@ -422,7 +423,7 @@ export class NinetailedPreviewPlugin
     const overrideKey = `${experienceId}:${key}`;
 
     // Only create new object if actually changing
-    if (this.variableOverwrites[overrideKey]?.value === value) {
+    if (isEqual(this.variableOverwrites[overrideKey]?.value, value)) {
       return; // No change needed
     }
 


### PR DESCRIPTION
An endless loop occurs in the 9T preview plugin when:

- One content entry references at least two personalized entries
- Both entries use the same personalization experience
- The experience has custom flags with JSON array/object values
- Both entries are rendered on the same page

it only compares references, not deep equality. When two personalized entries use the same experience and flag, but with different object values, the equality check always returns false, causing repeated updates and an endless loop.

