### PR TITLE
refactor: remove componentType from payloads and set default values i…

### DIFF
--- a/packages/plugins/analytics/src/lib/ElementSeenPayload.ts
+++ b/packages/plugins/analytics/src/lib/ElementSeenPayload.ts
@@ -5,7 +5,6 @@ export type ComponentViewEventComponentType = 'Entry' | 'Variable';
 
 // Base schema with shared properties
 const BaseSeenPayloadSchema = z.object({
-  componentType: z.union([z.literal('Entry'), z.literal('Variable')]),
   variant: z.object({ id: z.string() }).catchall(z.unknown()),
   variantIndex: z.number(),
 });
@@ -40,6 +39,7 @@ export const ElementSeenPayloadSchema = BaseSeenPayloadSchema.extend({
       description:
         'This is the default all visitors audience as no audience was set.',
     }),
+  componentType: z.literal('Entry').default('Entry'),
   seenFor: z.number().optional().default(0),
 });
 
@@ -50,6 +50,7 @@ export type ElementSeenPayload = Omit<
 
 // Variable specific schema
 export const VariableSeenPayloadSchema = BaseSeenPayloadSchema.extend({
+  componentType: z.literal('Variable').default('Variable'),
   variable: allowVariableTypeSchema,
   experienceId: z.string().optional(),
 });

--- a/packages/plugins/analytics/test/fixtures.ts
+++ b/packages/plugins/analytics/test/fixtures.ts
@@ -25,6 +25,5 @@ export const TRACK_COMPONENT_VIEW_PROPERTIES = {
     id: 'test',
     test: 'test',
   },
-  componentType: 'Entry' as const,
   variantIndex: 1,
 };

--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
@@ -62,7 +62,6 @@ describe('NinetailedInsightsPlugin', () => {
 
       ninetailed.observeElement({
         element,
-        componentType: 'Entry',
         variant: { id: `variant-id-${i + 1}` },
         variantIndex: i,
       });
@@ -114,7 +113,6 @@ describe('NinetailedInsightsPlugin', () => {
 
       ninetailed.observeElement({
         element,
-        componentType: 'Entry',
         variant: { id: `variant-id-${i + 1}` },
         variantIndex: i,
       });
@@ -149,7 +147,6 @@ describe('NinetailedInsightsPlugin', () => {
     for (let i = 0; i < 25; i++) {
       ninetailed.observeElement({
         element,
-        componentType: 'Entry',
         variant: { id: `variant-id-${i + 1}` },
         variantIndex: i,
       });
@@ -184,7 +181,6 @@ describe('NinetailedInsightsPlugin', () => {
     for (let i = 0; i < 25; i++) {
       ninetailed.observeElement({
         element,
-        componentType: 'Entry',
         variant: { id: `variant-id-1` },
         variantIndex: 0,
       });

--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.ts
@@ -84,8 +84,7 @@ export class NinetailedInsightsPlugin
   public override onHasSeenElement: EventHandler<ElementSeenPayload> = ({
     payload,
   }) => {
-    const { element, experience, variant, variantIndex, componentType } =
-      payload;
+    const { element, experience, variant, variantIndex } = payload;
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { element: _, ...elementPayloadWithoutElement } = payload;
@@ -125,7 +124,7 @@ export class NinetailedInsightsPlugin
     this.instance?.dispatch({
       type: COMPONENT_START,
       componentId,
-      componentType,
+      componentType: 'Entry',
       variantIndex,
       experienceId: experience?.id,
     });
@@ -162,7 +161,7 @@ export class NinetailedInsightsPlugin
   public override onHasSeenVariable: EventHandler<VariableSeenPayload> = ({
     payload,
   }) => {
-    const { variant, variantIndex, componentType, experienceId } = payload;
+    const { variant, variantIndex, experienceId } = payload;
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { variable: _, ...variablePayloadWithoutVariable } = payload;
@@ -202,7 +201,7 @@ export class NinetailedInsightsPlugin
     this.instance?.dispatch({
       type: COMPONENT_START,
       componentId,
-      componentType,
+      componentType: 'Variable',
       variantIndex,
       experienceId,
     });

--- a/packages/tests/javascript-integration/src/lib/multiple-analytics-plugins.spec.ts
+++ b/packages/tests/javascript-integration/src/lib/multiple-analytics-plugins.spec.ts
@@ -32,7 +32,6 @@ describe('A Ninetailed setup with multiple analytics plugins', () => {
         experience: { id: 'experience-1', name: 'test', type: 'nt_experiment' },
         variant: { id: 'variant-1', name: 'test' },
         audience: { id: 'audience-1', name: 'test' },
-        componentType: 'Entry',
         element: document.createElement('div'),
         variantIndex: 1,
       });


### PR DESCRIPTION
There is a problem with the way we added the componentType to distinguish between different types of components (Entry or Variable) as this was mistakenly adding to a type that the observeElement helper uses which does not make sense for it to be there.