### PR TITLE
Privacy Plugin doesn't prevent componentView events from being fired

### DIFF
--- a/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
+++ b/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
@@ -104,7 +104,6 @@ const IDENTIFY_EVENT_HANDLER =
 export class NinetailedPrivacyPlugin extends NinetailedPlugin {
   public name = PLUGIN_NAME;
   private _instance: AnalyticsInstance | null = null;
-  private _ready = false;
 
   private readonly config: PrivacyConfig;
   private readonly acceptedConsentConfig: PrivacyConfig;
@@ -205,16 +204,6 @@ export class NinetailedPrivacyPlugin extends NinetailedPlugin {
     await this.enableFeatures(this.getConfig().enabledFeatures);
 
     this.registerWindowHandlers();
-
-    this._ready = true;
-  };
-
-  public ready = async () => {
-    return this._ready;
-  };
-
-  public loaded = () => {
-    return this._ready;
   };
 
   private handleEventStart =
@@ -226,6 +215,9 @@ export class NinetailedPrivacyPlugin extends NinetailedPlugin {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ({ payload, abort }: { payload: any; abort: any }) => {
       if (!this.getConfig().allowedEvents.includes(eventType)) {
+        console.warn(
+          `[Ninetailed Privacy Plugin] The ${eventType} event was blocked, as it is not allowed to send by your configuration.`
+        );
         this.queue.push(payload);
 
         return abort();

--- a/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
+++ b/packages/plugins/privacy/src/NinetailedPrivacyPlugin.ts
@@ -142,6 +142,10 @@ export class NinetailedPrivacyPlugin extends NinetailedPlugin {
   }
 
   private isConsentGiven() {
+    // Pre-init can call isConsentGiven() via getConfig(); treat as "no consent" instead of throwing.
+    if (!this._instance) {
+      return false;
+    }
     const consent = this.instance.storage.getItem(CONSENT);
     return consent && consent === 'accepted';
   }
@@ -215,9 +219,6 @@ export class NinetailedPrivacyPlugin extends NinetailedPlugin {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ({ payload, abort }: { payload: any; abort: any }) => {
       if (!this.getConfig().allowedEvents.includes(eventType)) {
-        console.warn(
-          `[Ninetailed Privacy Plugin] The ${eventType} event was blocked, as it is not allowed to send by your configuration.`
-        );
         this.queue.push(payload);
 
         return abort();


### PR DESCRIPTION
# [NOTE: THIS TAKES PRIORITY FOR RELEASE]

## Problem

Component view (impression) events were being forwarded to the Insights API **before consent**, even though the Privacy plugin was installed and configured to block them.

This meant that users who had not yet opted-in still generated impression data, which violated the intended privacy gating.

## Symptoms

- `component` events appeared in network logs prior to consent being given.
- Privacy plugin logs/handlers sometimes never fired before the first impressions.
- Changing allowlists in the plugin config had no effect intermittently.
- Behavior looked “magical” and was hard to pin down because when we initially introduced this impression blocking features in the privacy plugin it was working, but at some point it stopped.

## Where the bug was introduced

The bug appeared when we added `loaded()` and `ready()` checks into the Privacy plugin and introduced an `await` in its `initialize()` function(#49)(SDK version [7.7.0](https://github.com/ninetailed-inc/experience.js/releases/tag/7.7.0)).

* The analytics core library (from David Wells) starts wiring and emitting events as soon as plugins are registered.
* It does **not** wait for plugins’ `loaded()`/`ready()` promises to resolve.
* Because our Privacy plugin’s `initialize()` was asynchronous (waiting on `enableFeatures`) and also reported readiness only after `loaded()` returned `true`, there was a _POSSIBLE_ **race window**: other plugins (like Insights) could dispatch `COMPONENT_START` before Privacy had registered its abort handler.

## Root cause

A _POSSIBLE_ **race condition** during plugin initialization:

- Analytics core begins delivering events right away.
- Privacy plugin delayed setting itself “ready” because of the `loaded()` check, even though it set itself ready quite early before anything was logged by the other plugins_.
- During that delay, other plugins’ emissions of `COMPONENT_START` → `COMPONENT` went through unblocked.
- As a result, impressions were sent to Insights before consent could be enforced.
- For some reason when we tested the plugin setup in isolation (bare bones setup of the analytics core lib) it seems to register the privacy plugin at some point and abort the events even if a few events were emitted before the plugin registered.

In short: **`loaded()` was being awaited/consulted by the analytics library in a way that delayed our gate**, and we didn’t need that extra check because `initialize()` completion is sufficient.

## Resolution (high-level)

- Removed the `loaded()` readiness checks.
- Ensured the Privacy plugin registers its handlers immediately and fire-and-forgets longer work (like enabling features).
- Kept plugin order so Privacy is initialized before any emitter plugins.

**Note: I say _Possible_ racing conditions as most of the behaviour is done in the background so it is hard to definitively prove if it is a racing condition.**