### PR TITLE
update snapshot radash dependency to the Ninetailed SDK plugin for pr…

### DIFF
--- a/packages/tests/generated-packages/src/lib/__snapshots__/generated-package-json.spec.ts.snap
+++ b/packages/tests/generated-packages/src/lib/__snapshots__/generated-package-json.spec.ts.snap
@@ -147,6 +147,7 @@ Object {
     "@ninetailed/experience.js-plugin-analytics": "*",
     "@ninetailed/experience.js-preview-bridge": "*",
     "@ninetailed/experience.js-shared": "*",
+    "radash": "10.9.0",
   },
   "description": "Ninetailed SDK plugin for preview",
   "keywords": Array [


### PR DESCRIPTION
The repo-wide test that validates generated package.json files in experience.js passed on the PR but failed during the release.