### PR TITLE
feat(tracking): Add view duration tracking

### DIFF
--- a/packages/plugins/analytics/src/lib/ElementPayload.ts
+++ b/packages/plugins/analytics/src/lib/ElementPayload.ts
@@ -48,6 +48,8 @@ const BaseElementInteractionPayloadSchema = BaseElementPayloadSchema.extend({
 export const ElementSeenPayloadSchema =
   BaseElementInteractionPayloadSchema.extend({
     seenFor: z.number().optional().default(0),
+    viewDurationMs: z.number().optional(),
+    componentViewId: z.string().optional(),
   });
 
 export type ElementSeenPayload = Omit<

--- a/packages/plugins/analytics/src/lib/ElementPayload.ts
+++ b/packages/plugins/analytics/src/lib/ElementPayload.ts
@@ -49,7 +49,7 @@ export const ElementSeenPayloadSchema =
   BaseElementInteractionPayloadSchema.extend({
     seenFor: z.number().optional().default(0),
     viewDurationMs: z.number().optional(),
-    componentViewId: z.string().optional(),
+    viewId: z.string().optional(),
   });
 
 export type ElementSeenPayload = Omit<
@@ -67,7 +67,7 @@ export type ElementClickedPayload = Omit<
 export const ElementHoveredPayloadSchema =
   BaseElementInteractionPayloadSchema.extend({
     hoverDurationMs: z.number(),
-    componentHoverId: z.string(),
+    hoverId: z.string(),
   });
 
 export type ElementHoveredPayload = Omit<

--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
@@ -133,7 +133,7 @@ describe('NinetailedInsightsPlugin', () => {
       expect(insightsApiClientSendEventBatchesMock).toHaveBeenCalledTimes(1);
     });
   });
-  it('should dedupe onHasSeenElement by componentViewId even when payloads differ', async () => {
+  it('should dedupe onHasSeenElement by viewId even when payloads differ', async () => {
     const insightsPlugin = new NinetailedInsightsPlugin();
     const dispatchMock = jest.fn();
     await insightsPlugin.initialize({
@@ -147,7 +147,7 @@ describe('NinetailedInsightsPlugin', () => {
       variant: { id: 'variant-id-1' },
       variantIndex: 0,
       seenFor: 2000,
-      componentViewId: 'component-view-id-1',
+      viewId: 'view-id-1',
       viewDurationMs: 2000,
     };
 
@@ -170,7 +170,7 @@ describe('NinetailedInsightsPlugin', () => {
     expect(dispatchMock).toHaveBeenCalledTimes(1);
     expect(dispatchMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        componentViewId: 'component-view-id-1',
+        viewId: 'view-id-1',
       })
     );
   });
@@ -226,7 +226,7 @@ describe('NinetailedInsightsPlugin', () => {
       expect(insightsApiClientSendEventBatchesMock).toHaveBeenCalledTimes(0);
     });
   });
-  it('should generate a new componentViewId and reset viewDurationMs across re-entries', async () => {
+  it('should generate a new viewId and reset viewDurationMs across re-entries', async () => {
     const insightsPlugin = new NinetailedInsightsPlugin();
     const ninetailed = setupNinetailedInstance([insightsPlugin]);
     insightsPlugin.setCredentials({
@@ -268,14 +268,14 @@ describe('NinetailedInsightsPlugin', () => {
     const componentEvents = pluginEvents.filter(
       (event: { type?: string }) => event.type === 'component'
     );
-    const componentViewIds = new Set(
-      componentEvents.map((event) => event['componentViewId'] as string)
+    const viewIds = new Set(
+      componentEvents.map((event) => event['viewId'] as string)
     );
     const durations = componentEvents.map(
       (event) => event['viewDurationMs'] as number
     );
 
-    expect(componentViewIds.size).toBe(2);
+    expect(viewIds.size).toBe(2);
     expect(Math.max(...durations)).toBeLessThan(4_000);
   });
   it('should flush component view heartbeats with sendBeacon on page hide', async () => {
@@ -330,7 +330,7 @@ describe('NinetailedInsightsPlugin', () => {
       expect.arrayContaining([
         expect.objectContaining({
           type: 'component',
-          componentViewId: expect.any(String),
+          viewId: expect.any(String),
           viewDurationMs: expect.any(Number),
         }),
       ])
@@ -457,13 +457,13 @@ describe('NinetailedInsightsPlugin', () => {
             componentId: expect.any(String),
             variantIndex: expect.any(Number),
             hoverDurationMs: expect.any(Number),
-            componentHoverId: expect.any(String),
+            hoverId: expect.any(String),
           })
         );
       });
     });
 
-    it('should generate a unique componentHoverId for each hover interaction', async () => {
+    it('should generate a unique hoverId for each hover interaction', async () => {
       const element = document.body.appendChild(document.createElement('div'));
       ninetailed.observeElement(
         {
@@ -499,12 +499,10 @@ describe('NinetailedInsightsPlugin', () => {
       );
 
       expect(hoverEvents.length).toBeGreaterThan(2);
-      const uniqueComponentHoverIds = new Set(
-        hoverEvents.map(
-          (hoverEvent) => hoverEvent['componentHoverId'] as string
-        )
+      const uniqueHoverIds = new Set(
+        hoverEvents.map((hoverEvent) => hoverEvent['hoverId'] as string)
       );
-      expect(uniqueComponentHoverIds.size).toBe(2);
+      expect(uniqueHoverIds.size).toBe(2);
     });
 
     it('should map component hover events to the correct component metadata when multiple elements are observed', async () => {
@@ -564,7 +562,7 @@ describe('NinetailedInsightsPlugin', () => {
         type: 'component_hover',
         componentId: expect.any(String),
         hoverDurationMs: expect.any(Number),
-        componentHoverId: expect.any(String),
+        hoverId: expect.any(String),
       };
       expect(hoverEvents).toEqual(
         expect.arrayContaining([
@@ -665,7 +663,7 @@ describe('NinetailedInsightsPlugin', () => {
         expect.objectContaining({
           type: 'component_hover',
           hoverDurationMs: expect.any(Number),
-          componentHoverId: expect.any(String),
+          hoverId: expect.any(String),
         }),
       ])
     );

--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
@@ -226,7 +226,7 @@ describe('NinetailedInsightsPlugin', () => {
       expect(insightsApiClientSendEventBatchesMock).toHaveBeenCalledTimes(0);
     });
   });
-  it('should keep componentViewId stable and increase viewDurationMs across view heartbeats', async () => {
+  it('should generate a new componentViewId and reset viewDurationMs across re-entries', async () => {
     const insightsPlugin = new NinetailedInsightsPlugin();
     const ninetailed = setupNinetailedInstance([insightsPlugin]);
     insightsPlugin.setCredentials({
@@ -275,8 +275,8 @@ describe('NinetailedInsightsPlugin', () => {
       (event) => event['viewDurationMs'] as number
     );
 
-    expect(componentViewIds.size).toBe(1);
-    expect(durations[durations.length - 1]).toBeGreaterThan(durations[0]);
+    expect(componentViewIds.size).toBe(2);
+    expect(Math.max(...durations)).toBeLessThan(4_000);
   });
   it('should flush component view heartbeats with sendBeacon on page hide', async () => {
     const insightsPlugin = new NinetailedInsightsPlugin();

--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
@@ -115,7 +115,7 @@ describe('NinetailedInsightsPlugin', () => {
       variantIndex: 0,
     });
     intersect(element, true);
-    jest.runAllTimers();
+    jest.advanceTimersByTime(2_100);
     jest.useRealTimers();
     expect(insightsApiClientSendEventBatchesMock).toHaveBeenCalledTimes(0);
     await ninetailed.identify('test-2');

--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
@@ -99,8 +99,7 @@ describe('NinetailedInsightsPlugin', () => {
       expect(insightsApiClientSendEventBatchesMock).not.toHaveBeenCalled();
     });
   });
-  // This is a rare case and would only happen if a profile changes while the user is on the same page and the component would change e.g. from baseline to variant 1
-  it('should track the same element with different payloads', async () => {
+  it('should dedupe the same element by componentViewId even when payloads differ', async () => {
     const insightsPlugin = new NinetailedInsightsPlugin();
     const ninetailed = setupNinetailedInstance([insightsPlugin]);
     insightsPlugin.setCredentials({
@@ -123,9 +122,21 @@ describe('NinetailedInsightsPlugin', () => {
     intersect(element, true);
     jest.advanceTimersByTime(2_100);
     jest.useRealTimers();
+
     await waitFor(() => {
-      expect(insightsApiClientSendEventBatchesMock).toHaveBeenCalledTimes(1);
+      const pluginEvents = (
+        insightsPlugin as unknown as { events: Record<string, unknown>[] }
+      ).events;
+      expect(pluginEvents).toHaveLength(1);
+      expect(pluginEvents[0]).toEqual(
+        expect.objectContaining({
+          type: 'component',
+          componentId: expect.any(String),
+        })
+      );
     });
+
+    expect(insightsApiClientSendEventBatchesMock).toHaveBeenCalledTimes(0);
   });
   it('should not track the same element with the same payload', async () => {
     const insightsPlugin = new NinetailedInsightsPlugin();

--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
@@ -99,7 +99,8 @@ describe('NinetailedInsightsPlugin', () => {
       expect(insightsApiClientSendEventBatchesMock).not.toHaveBeenCalled();
     });
   });
-  it('should dedupe the same element by componentViewId even when payloads differ', async () => {
+  // This is a rare case and would only happen if a profile changes while the user is on the same page and the component would change e.g. from baseline to variant 1
+  it('should track the same element with different payloads', async () => {
     const insightsPlugin = new NinetailedInsightsPlugin();
     const ninetailed = setupNinetailedInstance([insightsPlugin]);
     insightsPlugin.setCredentials({
@@ -120,23 +121,58 @@ describe('NinetailedInsightsPlugin', () => {
       });
     }
     intersect(element, true);
-    jest.advanceTimersByTime(2_100);
-    jest.useRealTimers();
 
+    // Run a bounded number of heartbeats to avoid an unbounded timer loop.
+    for (let i = 0; i < 25; i++) {
+      jest.runOnlyPendingTimers();
+    }
+    intersect(element, false);
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
     await waitFor(() => {
-      const pluginEvents = (
-        insightsPlugin as unknown as { events: Record<string, unknown>[] }
-      ).events;
-      expect(pluginEvents).toHaveLength(1);
-      expect(pluginEvents[0]).toEqual(
-        expect.objectContaining({
-          type: 'component',
-          componentId: expect.any(String),
-        })
-      );
+      expect(insightsApiClientSendEventBatchesMock).toHaveBeenCalledTimes(1);
+    });
+  });
+  it('should dedupe onHasSeenElement by componentViewId even when payloads differ', async () => {
+    const insightsPlugin = new NinetailedInsightsPlugin();
+    const dispatchMock = jest.fn();
+    await insightsPlugin.initialize({
+      instance: { dispatch: dispatchMock } as unknown as never,
     });
 
-    expect(insightsApiClientSendEventBatchesMock).toHaveBeenCalledTimes(0);
+    const basePayload = {
+      meta: { rid: 'rid-1', ts: new Date().toISOString() },
+      _: { originalAction: 'has_seen_element' },
+      element: document.createElement('div'),
+      variant: { id: 'variant-id-1' },
+      variantIndex: 0,
+      seenFor: 2000,
+      componentViewId: 'component-view-id-1',
+      viewDurationMs: 2000,
+    };
+
+    insightsPlugin.onHasSeenElement({
+      payload: basePayload,
+      instance: {} as never,
+      abort: jest.fn(),
+    });
+
+    insightsPlugin.onHasSeenElement({
+      payload: {
+        ...basePayload,
+        variant: { id: 'variant-id-2' },
+        variantIndex: 1,
+      },
+      instance: {} as never,
+      abort: jest.fn(),
+    });
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        componentViewId: 'component-view-id-1',
+      })
+    );
   });
   it('should not track the same element with the same payload', async () => {
     const insightsPlugin = new NinetailedInsightsPlugin();

--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.ts
@@ -52,6 +52,10 @@ type ObservedElementPayload = Omit<ElementSeenPayload, 'element'>;
 
 type VariableSeenPayloadWithoutVariable = Omit<VariableSeenPayload, 'variable'>;
 
+type ElementDedupeKey = string;
+type SeenDurationMs = number;
+type SeenElementDurationsByDedupeKey = Map<ElementDedupeKey, SeenDurationMs>;
+
 export class NinetailedInsightsPlugin
   extends NinetailedPlugin
   implements
@@ -65,7 +69,10 @@ export class NinetailedInsightsPlugin
 {
   public override name = 'ninetailed:insights';
 
-  private seenElements = new WeakMap<Element, Map<string, number>>();
+  private seenElements = new WeakMap<
+    Element,
+    SeenElementDurationsByDedupeKey
+  >();
 
   private seenVariables = new Map<
     string,

--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.ts
@@ -461,8 +461,12 @@ export class NinetailedInsightsPlugin
   }
 
   private buildSeenElementDedupeKey(payload: ObservedElementPayload) {
-    const { viewDurationMs: _, ...payloadWithoutViewDuration } = payload;
-
-    return JSON.stringify(payloadWithoutViewDuration);
+    return [
+      payload.componentViewId ?? 'no-component-view-id',
+      payload.seenFor ?? 0,
+      payload.variant.id,
+      payload.variantIndex,
+      payload.experience?.id ?? 'no-experience-id',
+    ].join(':');
   }
 }

--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.ts
@@ -48,13 +48,13 @@ import {
   ElementSeenPayloadSchema,
 } from '@ninetailed/experience.js-plugin-analytics';
 
-type ObservedElementPayload = Omit<ElementSeenPayload, 'element'>;
-
 type VariableSeenPayloadWithoutVariable = Omit<VariableSeenPayload, 'variable'>;
-
-type ElementDedupeKey = string;
+type ComponentViewDedupeKey = string;
 type SeenDurationMs = number;
-type SeenElementDurationsByDedupeKey = Map<ElementDedupeKey, SeenDurationMs>;
+type SeenElementDurationsByComponentViewId = Map<
+  ComponentViewDedupeKey,
+  SeenDurationMs
+>;
 
 export class NinetailedInsightsPlugin
   extends NinetailedPlugin
@@ -71,7 +71,7 @@ export class NinetailedInsightsPlugin
 
   private seenElements = new WeakMap<
     Element,
-    SeenElementDurationsByDedupeKey
+    SeenElementDurationsByComponentViewId
   >();
 
   private seenVariables = new Map<
@@ -117,15 +117,15 @@ export class NinetailedInsightsPlugin
       return;
     }
 
-    const { element, ...elementPayload } = sanitizedPayload.data;
     const {
+      element,
       componentType,
       experience,
       variant,
       variantIndex,
       viewDurationMs,
       componentViewId,
-    } = elementPayload;
+    } = sanitizedPayload.data;
 
     const componentId = variant.id;
 
@@ -133,10 +133,11 @@ export class NinetailedInsightsPlugin
       return;
     }
 
-    const dedupeKey = this.buildSeenElementDedupeKey(elementPayload);
-    const latestSeenDurationsBySession =
+    const dedupeKey = componentViewId ?? 'no-component-view-id';
+    const latestSeenDurationsByComponentViewId =
       this.seenElements.get(element) || new Map<string, number>();
-    const latestSeenDurationMs = latestSeenDurationsBySession.get(dedupeKey);
+    const latestSeenDurationMs =
+      latestSeenDurationsByComponentViewId.get(dedupeKey);
     const currentSeenDurationMs = viewDurationMs ?? 0;
 
     if (
@@ -146,8 +147,8 @@ export class NinetailedInsightsPlugin
       return;
     }
 
-    latestSeenDurationsBySession.set(dedupeKey, currentSeenDurationMs);
-    this.seenElements.set(element, latestSeenDurationsBySession);
+    latestSeenDurationsByComponentViewId.set(dedupeKey, currentSeenDurationMs);
+    this.seenElements.set(element, latestSeenDurationsByComponentViewId);
 
     /**
      * Intentionally sending a COMPONENT_START event instead of COMPONENT.
@@ -465,15 +466,5 @@ export class NinetailedInsightsPlugin
 
   public setEventBuilder(eventBuilder: EventBuilder) {
     this.eventBuilder = eventBuilder;
-  }
-
-  private buildSeenElementDedupeKey(payload: ObservedElementPayload) {
-    return [
-      payload.componentViewId ?? 'no-component-view-id',
-      payload.seenFor ?? 0,
-      payload.variant.id,
-      payload.variantIndex,
-      payload.experience?.id ?? 'no-experience-id',
-    ].join(':');
   }
 }

--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.ts
@@ -49,12 +49,9 @@ import {
 } from '@ninetailed/experience.js-plugin-analytics';
 
 type VariableSeenPayloadWithoutVariable = Omit<VariableSeenPayload, 'variable'>;
-type ComponentViewDedupeKey = string;
+type ViewDedupeKey = string;
 type SeenDurationMs = number;
-type SeenElementDurationsByComponentViewId = Map<
-  ComponentViewDedupeKey,
-  SeenDurationMs
->;
+type SeenElementDurationsByViewId = Map<ViewDedupeKey, SeenDurationMs>;
 
 export class NinetailedInsightsPlugin
   extends NinetailedPlugin
@@ -69,10 +66,7 @@ export class NinetailedInsightsPlugin
 {
   public override name = 'ninetailed:insights';
 
-  private seenElements = new WeakMap<
-    Element,
-    SeenElementDurationsByComponentViewId
-  >();
+  private seenElements = new WeakMap<Element, SeenElementDurationsByViewId>();
 
   private seenVariables = new Map<
     string,
@@ -124,7 +118,7 @@ export class NinetailedInsightsPlugin
       variant,
       variantIndex,
       viewDurationMs,
-      componentViewId,
+      viewId,
     } = sanitizedPayload.data;
 
     const componentId = variant.id;
@@ -133,11 +127,10 @@ export class NinetailedInsightsPlugin
       return;
     }
 
-    const dedupeKey = componentViewId ?? 'no-component-view-id';
-    const latestSeenDurationsByComponentViewId =
+    const dedupeKey = viewId ?? 'no-view-id';
+    const latestSeenDurationsByViewId =
       this.seenElements.get(element) || new Map<string, number>();
-    const latestSeenDurationMs =
-      latestSeenDurationsByComponentViewId.get(dedupeKey);
+    const latestSeenDurationMs = latestSeenDurationsByViewId.get(dedupeKey);
     const currentSeenDurationMs = viewDurationMs ?? 0;
 
     if (
@@ -147,8 +140,8 @@ export class NinetailedInsightsPlugin
       return;
     }
 
-    latestSeenDurationsByComponentViewId.set(dedupeKey, currentSeenDurationMs);
-    this.seenElements.set(element, latestSeenDurationsByComponentViewId);
+    latestSeenDurationsByViewId.set(dedupeKey, currentSeenDurationMs);
+    this.seenElements.set(element, latestSeenDurationsByViewId);
 
     /**
      * Intentionally sending a COMPONENT_START event instead of COMPONENT.
@@ -166,7 +159,7 @@ export class NinetailedInsightsPlugin
       variantIndex,
       experienceId: experience?.id,
       viewDurationMs,
-      componentViewId,
+      viewId,
     });
   };
 
@@ -184,7 +177,7 @@ export class NinetailedInsightsPlugin
       variantIndex,
       componentType,
       viewDurationMs,
-      componentViewId,
+      viewId,
     } = payload;
 
     const event = this.eventBuilder.component(
@@ -193,7 +186,7 @@ export class NinetailedInsightsPlugin
       experienceId,
       variantIndex,
       viewDurationMs,
-      componentViewId
+      viewId
     );
 
     this.events.push(event);
@@ -287,7 +280,7 @@ export class NinetailedInsightsPlugin
       variant,
       variantIndex,
       hoverDurationMs,
-      componentHoverId,
+      hoverId,
     } = sanitizedPayload.data;
 
     const componentId = variant.id;
@@ -303,7 +296,7 @@ export class NinetailedInsightsPlugin
       variantIndex,
       experienceId: experience?.id,
       hoverDurationMs,
-      componentHoverId,
+      hoverId,
     });
   };
 
@@ -323,14 +316,14 @@ export class NinetailedInsightsPlugin
       variantIndex,
       componentType,
       hoverDurationMs,
-      componentHoverId,
+      hoverId,
     } = payload;
 
     const event = this.eventBuilder.componentHover(
       componentId,
       componentType,
       hoverDurationMs,
-      componentHoverId,
+      hoverId,
       experienceId,
       variantIndex
     );
@@ -408,10 +401,7 @@ export class NinetailedInsightsPlugin
 
     this.profile = profile ?? undefined;
 
-    this.seenElements = new WeakMap<
-      Element,
-      SeenElementDurationsByComponentViewId
-    >();
+    this.seenElements = new WeakMap<Element, SeenElementDurationsByViewId>();
   };
 
   public [PAGE_HIDDEN] = () => {

--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.ts
@@ -408,7 +408,10 @@ export class NinetailedInsightsPlugin
 
     this.profile = profile ?? undefined;
 
-    this.seenElements = new WeakMap<Element, Map<string, number>>();
+    this.seenElements = new WeakMap<
+      Element,
+      SeenElementDurationsByComponentViewId
+    >();
   };
 
   public [PAGE_HIDDEN] = () => {

--- a/packages/sdks/javascript/src/lib/ElementHoverObserver.ts
+++ b/packages/sdks/javascript/src/lib/ElementHoverObserver.ts
@@ -2,7 +2,7 @@ export type ElementHoverObserverOptions = {
   onElementHover: (
     element: Element,
     hoverDurationMs: number,
-    componentHoverId: string
+    hoverId: string
   ) => void;
   componentHoverTrackingThreshold?: number;
   heartbeatIntervalMs?: number;
@@ -10,7 +10,7 @@ export type ElementHoverObserverOptions = {
 };
 
 type ElementHoverSession = {
-  componentHoverId: string;
+  hoverId: string;
   hoverStartTimestamp: number;
   lastReportedMs: number;
 };
@@ -59,7 +59,7 @@ export class ElementHoverObserver {
       }
 
       this._activeHoverSessions.set(element, {
-        componentHoverId: crypto.randomUUID(),
+        hoverId: crypto.randomUUID(),
         hoverStartTimestamp: Date.now(),
         lastReportedMs: 0,
       });
@@ -184,7 +184,7 @@ export class ElementHoverObserver {
     this._options.onElementHover(
       element,
       hoverDurationMs,
-      hoverSession.componentHoverId
+      hoverSession.hoverId
     );
     hoverSession.lastReportedMs = hoverDurationMs;
   }

--- a/packages/sdks/javascript/src/lib/ElementSeenObserver.ts
+++ b/packages/sdks/javascript/src/lib/ElementSeenObserver.ts
@@ -1,19 +1,57 @@
 import type { ObserveOptions } from './types/ObserveOptions';
 
 export type ElementSeenObserverOptions = {
-  onElementSeen: (element: Element, delay?: number) => void;
+  onElementSeen: (
+    element: Element,
+    delay: number,
+    viewDurationMs: number,
+    componentViewId: string
+  ) => void;
+  heartbeatIntervalMs?: number;
+  extendedHeartbeatIntervalMs?: number;
+  extendedHeartbeatThresholdMs?: number;
+  minimumHeartbeatIncrementMs?: number;
 };
 
 export type { ObserveOptions } from './types/ObserveOptions';
 
+type ElementViewState = {
+  componentViewId: string;
+  delays: Set<number>;
+  enterTimestamp: number | null;
+  accumulatedVisibleDurationMs: number;
+  lastReportedDurationByDelay: Map<number, number>;
+};
+
+type EmitViewIfNeededParams = {
+  element: Element;
+  viewState: ElementViewState;
+  now: number;
+  forceReport: boolean;
+};
+
 export class ElementSeenObserver {
   private _intersectionObserver?: IntersectionObserver;
-  private _elementDelays: WeakMap<Element, number[]>;
-  private _intersectionTimers: WeakMap<Element, number[]>;
+  private _elementViewState: Map<Element, ElementViewState>;
+  private _heartbeatTimer: number | null;
+  private _scheduledHeartbeatIntervalMs: number | null;
+
+  private readonly heartbeatIntervalMs: number;
+  private readonly extendedHeartbeatIntervalMs: number;
+  private readonly extendedHeartbeatThresholdMs: number;
+  private readonly minimumHeartbeatIncrementMs: number;
 
   constructor(private _options: ElementSeenObserverOptions) {
-    this._elementDelays = new WeakMap<Element, number[]>();
-    this._intersectionTimers = new WeakMap<Element, number[]>();
+    this._elementViewState = new Map();
+    this._heartbeatTimer = null;
+    this._scheduledHeartbeatIntervalMs = null;
+    this.heartbeatIntervalMs = _options.heartbeatIntervalMs ?? 2000;
+    this.extendedHeartbeatIntervalMs =
+      _options.extendedHeartbeatIntervalMs ?? 10000;
+    this.extendedHeartbeatThresholdMs =
+      _options.extendedHeartbeatThresholdMs ?? 10000;
+    this.minimumHeartbeatIncrementMs =
+      _options.minimumHeartbeatIncrementMs ?? 1000;
 
     if (typeof IntersectionObserver !== 'undefined') {
       this._intersectionObserver = new IntersectionObserver(
@@ -23,41 +61,235 @@ export class ElementSeenObserver {
   }
 
   private onIntersection(entries: IntersectionObserverEntry[]) {
+    const now = Date.now();
+
     entries.forEach((entry) => {
       const { isIntersecting, target } = entry;
+      const viewState = this._elementViewState.get(target);
+
+      if (!viewState) {
+        return;
+      }
 
       if (isIntersecting) {
-        const delays = this._elementDelays.get(target);
-
-        delays?.forEach((delay) => {
-          const timeOut = window.setTimeout(() => {
-            this._options.onElementSeen(target, delay);
-          }, delay);
-          const currentTimers = this._intersectionTimers.get(target) || [];
-          this._intersectionTimers.set(target, [...currentTimers, timeOut]);
-        });
-      } else {
-        const timeOuts = this._intersectionTimers.get(target);
-        timeOuts?.forEach((timeOut) => {
-          if (typeof timeOut !== 'undefined') {
-            window.clearTimeout(timeOut);
-          }
-        });
+        if (viewState.enterTimestamp === null) {
+          viewState.enterTimestamp = now;
+          this.startHeartbeatIfNeeded();
+        }
+        return;
       }
+
+      this.stopTrackingVisibleTime(target, true, now);
     });
   }
 
   public observe(element: Element, options?: ObserveOptions) {
-    const delays = this._elementDelays.get(element) || [];
+    const delay = Math.max(0, options?.delay ?? 0);
+    const viewState = this._elementViewState.get(element);
 
-    this._elementDelays.set(
-      element,
-      Array.from(new Set([...delays, options?.delay || 0]))
-    );
+    if (!viewState) {
+      this._elementViewState.set(element, {
+        componentViewId: crypto.randomUUID(),
+        delays: new Set([delay]),
+        enterTimestamp: null,
+        accumulatedVisibleDurationMs: 0,
+        lastReportedDurationByDelay: new Map(),
+      });
+    } else {
+      viewState.delays.add(delay);
+    }
+
     this._intersectionObserver?.observe(element);
   }
 
   public unobserve(element: Element) {
+    this.stopTrackingVisibleTime(element, true, Date.now());
+    this._elementViewState.delete(element);
     this._intersectionObserver?.unobserve(element);
+    this.stopHeartbeatIfIdle();
+  }
+
+  public flushActiveViews() {
+    const now = Date.now();
+
+    this._elementViewState.forEach((viewState, element) => {
+      if (viewState.enterTimestamp === null) {
+        return;
+      }
+
+      this.emitViewIfNeeded({
+        element,
+        viewState,
+        now,
+        forceReport: true,
+      });
+    });
+  }
+
+  private runHeartbeat = () => {
+    this._heartbeatTimer = null;
+    this._scheduledHeartbeatIntervalMs = null;
+
+    const now = Date.now();
+
+    this._elementViewState.forEach((viewState, element) => {
+      if (viewState.enterTimestamp === null) {
+        return;
+      }
+
+      this.emitViewIfNeeded({
+        element,
+        viewState,
+        now,
+        forceReport: false,
+      });
+    });
+
+    this.startHeartbeatIfNeeded();
+  };
+
+  private startHeartbeatIfNeeded() {
+    if (this.getActiveViewCount() === 0) {
+      this.stopHeartbeatIfIdle();
+      return;
+    }
+
+    const now = Date.now();
+    const heartbeatIntervalMs = this.getHeartbeatIntervalMs(now);
+
+    if (
+      this._heartbeatTimer !== null &&
+      this._scheduledHeartbeatIntervalMs === heartbeatIntervalMs
+    ) {
+      return;
+    }
+
+    if (this._heartbeatTimer !== null) {
+      window.clearTimeout(this._heartbeatTimer);
+    }
+
+    this._scheduledHeartbeatIntervalMs = heartbeatIntervalMs;
+    this._heartbeatTimer = window.setTimeout(
+      this.runHeartbeat,
+      heartbeatIntervalMs
+    );
+  }
+
+  private stopHeartbeatIfIdle() {
+    if (this.getActiveViewCount() > 0 || this._heartbeatTimer === null) {
+      return;
+    }
+
+    window.clearTimeout(this._heartbeatTimer);
+    this._heartbeatTimer = null;
+    this._scheduledHeartbeatIntervalMs = null;
+  }
+
+  private getActiveViewCount() {
+    let activeViewCount = 0;
+
+    this._elementViewState.forEach((viewState) => {
+      if (viewState.enterTimestamp !== null) {
+        activeViewCount += 1;
+      }
+    });
+
+    return activeViewCount;
+  }
+
+  private getHeartbeatIntervalMs(now: number) {
+    let hasFreshView = false;
+
+    this._elementViewState.forEach((viewState) => {
+      if (viewState.enterTimestamp === null) {
+        return;
+      }
+
+      const viewDurationMs = this.getViewDurationMs(viewState, now);
+      if (viewDurationMs < this.extendedHeartbeatThresholdMs) {
+        hasFreshView = true;
+      }
+    });
+
+    return hasFreshView
+      ? this.heartbeatIntervalMs
+      : this.extendedHeartbeatIntervalMs;
+  }
+
+  private stopTrackingVisibleTime(
+    element: Element,
+    emitFinalHeartbeat: boolean,
+    now: number
+  ) {
+    const viewState = this._elementViewState.get(element);
+
+    if (!viewState) {
+      this.stopHeartbeatIfIdle();
+      return;
+    }
+
+    if (viewState.enterTimestamp === null) {
+      this.stopHeartbeatIfIdle();
+      return;
+    }
+
+    viewState.accumulatedVisibleDurationMs += now - viewState.enterTimestamp;
+    viewState.enterTimestamp = null;
+
+    if (emitFinalHeartbeat) {
+      this.emitViewIfNeeded({
+        element,
+        viewState,
+        now,
+        forceReport: true,
+      });
+    }
+
+    this.stopHeartbeatIfIdle();
+  }
+
+  private getViewDurationMs(viewState: ElementViewState, now: number) {
+    if (viewState.enterTimestamp === null) {
+      return viewState.accumulatedVisibleDurationMs;
+    }
+
+    return (
+      viewState.accumulatedVisibleDurationMs + (now - viewState.enterTimestamp)
+    );
+  }
+
+  private emitViewIfNeeded({
+    element,
+    viewState,
+    now,
+    forceReport,
+  }: EmitViewIfNeededParams) {
+    const viewDurationMs = this.getViewDurationMs(viewState, now);
+
+    viewState.delays.forEach((delay) => {
+      if (viewDurationMs < delay) {
+        return;
+      }
+
+      const lastReportedDurationMs =
+        viewState.lastReportedDurationByDelay.get(delay) ?? 0;
+      const durationDelta = viewDurationMs - lastReportedDurationMs;
+
+      if (durationDelta <= 0) {
+        return;
+      }
+
+      if (!forceReport && durationDelta < this.minimumHeartbeatIncrementMs) {
+        return;
+      }
+
+      this._options.onElementSeen(
+        element,
+        delay,
+        viewDurationMs,
+        viewState.componentViewId
+      );
+      viewState.lastReportedDurationByDelay.set(delay, viewDurationMs);
+    });
   }
 }

--- a/packages/sdks/javascript/src/lib/ElementSeenObserver.ts
+++ b/packages/sdks/javascript/src/lib/ElementSeenObserver.ts
@@ -73,6 +73,16 @@ export class ElementSeenObserver {
 
       if (isIntersecting) {
         if (viewState.enterTimestamp === null) {
+          const hasPreviousViewSession =
+            viewState.accumulatedVisibleDurationMs > 0 ||
+            viewState.lastReportedDurationByDelay.size > 0;
+
+          if (hasPreviousViewSession) {
+            viewState.componentViewId = crypto.randomUUID();
+            viewState.accumulatedVisibleDurationMs = 0;
+            viewState.lastReportedDurationByDelay.clear();
+          }
+
           viewState.enterTimestamp = now;
           this.startHeartbeatIfNeeded();
         }

--- a/packages/sdks/javascript/src/lib/ElementSeenObserver.ts
+++ b/packages/sdks/javascript/src/lib/ElementSeenObserver.ts
@@ -5,7 +5,7 @@ export type ElementSeenObserverOptions = {
     element: Element,
     delay: number,
     viewDurationMs: number,
-    componentViewId: string
+    viewId: string
   ) => void;
   heartbeatIntervalMs?: number;
   extendedHeartbeatIntervalMs?: number;
@@ -16,7 +16,7 @@ export type ElementSeenObserverOptions = {
 export type { ObserveOptions } from './types/ObserveOptions';
 
 type ElementViewState = {
-  componentViewId: string;
+  viewId: string;
   delays: Set<number>;
   enterTimestamp: number | null;
   accumulatedVisibleDurationMs: number;
@@ -78,7 +78,7 @@ export class ElementSeenObserver {
             viewState.lastReportedDurationByDelay.size > 0;
 
           if (hasPreviousViewSession) {
-            viewState.componentViewId = crypto.randomUUID();
+            viewState.viewId = crypto.randomUUID();
             viewState.accumulatedVisibleDurationMs = 0;
             viewState.lastReportedDurationByDelay.clear();
           }
@@ -99,7 +99,7 @@ export class ElementSeenObserver {
 
     if (!viewState) {
       this._elementViewState.set(element, {
-        componentViewId: crypto.randomUUID(),
+        viewId: crypto.randomUUID(),
         delays: new Set([delay]),
         enterTimestamp: null,
         accumulatedVisibleDurationMs: 0,
@@ -297,7 +297,7 @@ export class ElementSeenObserver {
         element,
         delay,
         viewDurationMs,
-        viewState.componentViewId
+        viewState.viewId
       );
       viewState.lastReportedDurationByDelay.set(delay, viewDurationMs);
     });

--- a/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
@@ -381,7 +381,7 @@ describe('Ninetailed core class', () => {
         );
       });
     });
-    it('should generate a new componentViewId and reset viewDurationMs across re-entries', async () => {
+    it('should generate a new viewId and reset viewDurationMs across re-entries', async () => {
       const element = document.body.appendChild(document.createElement('div'));
       const seenPlugin = new TestElementSeenPlugin();
       const { ninetailed } = mockProfile([seenPlugin]);
@@ -411,12 +411,10 @@ describe('Ninetailed core class', () => {
       const payloads = seenPlugin.onElementSeenMock.mock.calls.map(
         ([payload]) => payload
       ) as ElementSeenPayload[];
-      const uniqueComponentViewIds = new Set(
-        payloads.map((payload) => payload.componentViewId)
-      );
+      const uniqueViewIds = new Set(payloads.map((payload) => payload.viewId));
       const durations = payloads.map((payload) => payload.viewDurationMs ?? 0);
 
-      expect(uniqueComponentViewIds.size).toBe(2);
+      expect(uniqueViewIds.size).toBe(2);
       expect(Math.max(...durations)).toBeLessThan(4_000);
     });
     it('should switch to a slower heartbeat cadence after long views', async () => {
@@ -677,14 +675,13 @@ describe('Ninetailed core class', () => {
               variant: expect.objectContaining({ id: 'variant-id' }),
               variantIndex: 1,
               hoverDurationMs: expect.any(Number),
-              componentHoverId: expect.any(String),
+              hoverId: expect.any(String),
             })
           );
         });
         expect(
-          new Set(
-            hoverPayloads.map((hoverPayload) => hoverPayload.componentHoverId)
-          ).size
+          new Set(hoverPayloads.map((hoverPayload) => hoverPayload.hoverId))
+            .size
         ).toBe(1);
         expect(
           Math.max(
@@ -732,7 +729,7 @@ describe('Ninetailed core class', () => {
               variant: expect.objectContaining({ id: 'variant-id' }),
               variantIndex: 1,
               hoverDurationMs: expect.any(Number),
-              componentHoverId: expect.any(String),
+              hoverId: expect.any(String),
             })
           );
         });
@@ -834,14 +831,13 @@ describe('Ninetailed core class', () => {
               variant: expect.objectContaining({ id: 'variant-id' }),
               variantIndex: 1,
               hoverDurationMs: expect.any(Number),
-              componentHoverId: expect.any(String),
+              hoverId: expect.any(String),
             })
           );
         });
         expect(
-          new Set(
-            hoverPayloads.map((hoverPayload) => hoverPayload.componentHoverId)
-          ).size
+          new Set(hoverPayloads.map((hoverPayload) => hoverPayload.hoverId))
+            .size
         ).toBe(2);
       });
 
@@ -898,7 +894,7 @@ describe('Ninetailed core class', () => {
               variant: expect.objectContaining({ id: expect.any(String) }),
               variantIndex: expect.any(Number),
               hoverDurationMs: expect.any(Number),
-              componentHoverId: expect.any(String),
+              hoverId: expect.any(String),
             })
           );
         });
@@ -958,7 +954,7 @@ describe('Ninetailed core class', () => {
             variant: expect.objectContaining({ id: 'variant-id' }),
             variantIndex: 1,
             hoverDurationMs: expect.any(Number),
-            componentHoverId: expect.any(String),
+            hoverId: expect.any(String),
           })
         );
       });

--- a/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
@@ -381,7 +381,7 @@ describe('Ninetailed core class', () => {
         );
       });
     });
-    it('should keep componentViewId stable and report cumulative viewDurationMs across re-entries', async () => {
+    it('should generate a new componentViewId and reset viewDurationMs across re-entries', async () => {
       const element = document.body.appendChild(document.createElement('div'));
       const seenPlugin = new TestElementSeenPlugin();
       const { ninetailed } = mockProfile([seenPlugin]);
@@ -416,8 +416,8 @@ describe('Ninetailed core class', () => {
       );
       const durations = payloads.map((payload) => payload.viewDurationMs ?? 0);
 
-      expect(uniqueComponentViewIds.size).toBe(1);
-      expect(durations[durations.length - 1]).toBeGreaterThan(durations[0]);
+      expect(uniqueComponentViewIds.size).toBe(2);
+      expect(Math.max(...durations)).toBeLessThan(4_000);
     });
     it('should switch to a slower heartbeat cadence after long views', async () => {
       const element = document.body.appendChild(document.createElement('div'));

--- a/packages/sdks/javascript/src/lib/Ninetailed.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.ts
@@ -597,7 +597,12 @@ export class Ninetailed implements NinetailedInstance {
     this.elementHoverObserver.unobserve(element);
   };
 
-  private onElementSeen = (element: Element, delay?: number) => {
+  private onElementSeen = (
+    element: Element,
+    delay: number,
+    viewDurationMs: number,
+    componentViewId: string
+  ) => {
     const payloads = this.observedElements.get(element);
 
     if (Array.isArray(payloads) && payloads.length > 0) {
@@ -607,6 +612,8 @@ export class Ninetailed implements NinetailedInstance {
           element,
           type: HAS_SEEN_ELEMENT,
           seenFor: delay,
+          viewDurationMs,
+          componentViewId,
         });
       }
     }
@@ -1130,6 +1137,7 @@ export class Ninetailed implements NinetailedInstance {
 
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'hidden') {
+        this.elementSeenObserver.flushActiveViews();
         this.elementHoverObserver.flushActiveHovers();
         this.instance.dispatch({ type: PAGE_HIDDEN });
       }

--- a/packages/sdks/javascript/src/lib/Ninetailed.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.ts
@@ -601,7 +601,7 @@ export class Ninetailed implements NinetailedInstance {
     element: Element,
     delay: number,
     viewDurationMs: number,
-    componentViewId: string
+    viewId: string
   ) => {
     const payloads = this.observedElements.get(element);
 
@@ -613,7 +613,7 @@ export class Ninetailed implements NinetailedInstance {
           type: HAS_SEEN_ELEMENT,
           seenFor: delay,
           viewDurationMs,
-          componentViewId,
+          viewId,
         });
       }
     }
@@ -636,7 +636,7 @@ export class Ninetailed implements NinetailedInstance {
   private onElementHovered = (
     element: Element,
     hoverDurationMs: number,
-    componentHoverId: string
+    hoverId: string
   ) => {
     const payloads = this.observedElements.get(element);
 
@@ -647,7 +647,7 @@ export class Ninetailed implements NinetailedInstance {
           element,
           type: HAS_HOVERED_ELEMENT,
           hoverDurationMs,
-          componentHoverId,
+          hoverId,
         });
       }
     }

--- a/packages/sdks/javascript/src/lib/NinetailedCorePlugin/actions.ts
+++ b/packages/sdks/javascript/src/lib/NinetailedCorePlugin/actions.ts
@@ -26,6 +26,8 @@ type ReadyAction = {
 type HasSeenElementAction = {
   type: typeof HAS_SEEN_ELEMENT;
   seenFor: number | undefined;
+  viewDurationMs?: number;
+  componentViewId?: string;
   element: Element;
 };
 

--- a/packages/sdks/javascript/src/lib/NinetailedCorePlugin/actions.ts
+++ b/packages/sdks/javascript/src/lib/NinetailedCorePlugin/actions.ts
@@ -27,7 +27,7 @@ type HasSeenElementAction = {
   type: typeof HAS_SEEN_ELEMENT;
   seenFor: number | undefined;
   viewDurationMs?: number;
-  componentViewId?: string;
+  viewId?: string;
   element: Element;
 };
 
@@ -40,7 +40,7 @@ type HasHoveredElementAction = {
   type: typeof HAS_HOVERED_ELEMENT;
   element: Element;
   hoverDurationMs: number;
-  componentHoverId: string;
+  hoverId: string;
 };
 
 type HasSeenVariableAction = {

--- a/packages/sdks/javascript/src/lib/utils/EventBuilder.ts
+++ b/packages/sdks/javascript/src/lib/utils/EventBuilder.ts
@@ -79,6 +79,8 @@ export class EventBuilder {
     componentType: ComponentViewEventComponentType,
     experienceId?: string,
     variantIndex?: number,
+    viewDurationMs?: number,
+    componentViewId?: string,
     data?: ComponentData
   ) {
     return buildComponentViewEvent({
@@ -87,6 +89,8 @@ export class EventBuilder {
       componentType: componentType || 'Entry',
       experienceId,
       variantIndex: variantIndex || 0,
+      viewDurationMs,
+      componentViewId,
     });
   }
 

--- a/packages/sdks/javascript/src/lib/utils/EventBuilder.ts
+++ b/packages/sdks/javascript/src/lib/utils/EventBuilder.ts
@@ -80,7 +80,7 @@ export class EventBuilder {
     experienceId?: string,
     variantIndex?: number,
     viewDurationMs?: number,
-    componentViewId?: string,
+    viewId?: string,
     data?: ComponentData
   ) {
     return buildComponentViewEvent({
@@ -90,7 +90,7 @@ export class EventBuilder {
       experienceId,
       variantIndex: variantIndex || 0,
       viewDurationMs,
-      componentViewId,
+      viewId,
     });
   }
 
@@ -114,7 +114,7 @@ export class EventBuilder {
     componentId: string,
     componentType: ComponentInteractionEventComponentType,
     hoverDurationMs: number,
-    componentHoverId: string,
+    hoverId: string,
     experienceId?: string,
     variantIndex?: number,
     data?: ComponentData
@@ -123,7 +123,7 @@ export class EventBuilder {
       ...this.buildEventBase(data),
       componentId,
       componentType: componentType || 'Entry',
-      componentHoverId,
+      hoverId,
       hoverDurationMs,
       experienceId,
       variantIndex: variantIndex || 0,

--- a/packages/sdks/shared/src/lib/event/build-component-hover-event.ts
+++ b/packages/sdks/shared/src/lib/event/build-component-hover-event.ts
@@ -9,7 +9,7 @@ export type BuildComponentHoverEventData = Object.Omit<
     {
       componentId: string;
       componentType: 'Entry';
-      componentHoverId: string;
+      hoverId: string;
       hoverDurationMs: number;
       experienceId?: string;
       variantIndex?: number;
@@ -26,7 +26,7 @@ export const buildComponentHoverEvent = (
     ...buildEvent({ ...data, type: 'component_hover' }),
     componentType: data.componentType,
     componentId: data.componentId,
-    componentHoverId: data.componentHoverId,
+    hoverId: data.hoverId,
     hoverDurationMs: data.hoverDurationMs,
     experienceId: data.experienceId,
     variantIndex: data.variantIndex,

--- a/packages/sdks/shared/src/lib/event/build-component-view-event.ts
+++ b/packages/sdks/shared/src/lib/event/build-component-view-event.ts
@@ -14,6 +14,8 @@ export type BuildComponentViewEventData = Object.Omit<
       componentType: ComponentViewEventComponentType;
       experienceId?: string;
       variantIndex?: number;
+      viewDurationMs?: number;
+      componentViewId?: string;
     },
     'deep'
   >,
@@ -29,5 +31,7 @@ export const buildComponentViewEvent = (
     componentId: data.componentId,
     experienceId: data.experienceId,
     variantIndex: data.variantIndex,
+    viewDurationMs: data.viewDurationMs,
+    componentViewId: data.componentViewId,
   };
 };

--- a/packages/sdks/shared/src/lib/event/build-component-view-event.ts
+++ b/packages/sdks/shared/src/lib/event/build-component-view-event.ts
@@ -15,7 +15,7 @@ export type BuildComponentViewEventData = Object.Omit<
       experienceId?: string;
       variantIndex?: number;
       viewDurationMs?: number;
-      componentViewId?: string;
+      viewId?: string;
     },
     'deep'
   >,
@@ -32,6 +32,6 @@ export const buildComponentViewEvent = (
     experienceId: data.experienceId,
     variantIndex: data.variantIndex,
     viewDurationMs: data.viewDurationMs,
-    componentViewId: data.componentViewId,
+    viewId: data.viewId,
   };
 };

--- a/packages/sdks/shared/src/lib/types/Event/ComponentHoverEvent.ts
+++ b/packages/sdks/shared/src/lib/types/Event/ComponentHoverEvent.ts
@@ -7,7 +7,7 @@ export type ComponentHoverEvent = Object.Merge<
     type: 'component_hover';
     componentType: 'Entry';
     componentId: string;
-    componentHoverId: string;
+    hoverId: string;
     hoverDurationMs: number;
     experienceId?: string;
     variantIndex?: number;

--- a/packages/sdks/shared/src/lib/types/Event/ComponentViewEvent.ts
+++ b/packages/sdks/shared/src/lib/types/Event/ComponentViewEvent.ts
@@ -12,5 +12,7 @@ export type ComponentViewEvent = Object.Merge<
     componentId: string;
     experienceId?: string;
     variantIndex?: number;
+    viewDurationMs?: number;
+    componentViewId?: string;
   }
 >;

--- a/packages/sdks/shared/src/lib/types/Event/ComponentViewEvent.ts
+++ b/packages/sdks/shared/src/lib/types/Event/ComponentViewEvent.ts
@@ -13,6 +13,6 @@ export type ComponentViewEvent = Object.Merge<
     experienceId?: string;
     variantIndex?: number;
     viewDurationMs?: number;
-    componentViewId?: string;
+    viewId?: string;
   }
 >;


### PR DESCRIPTION
This PR extends view tracking, to enable us to determine not only if an element has been seen but also how long it was seen for.

- Added `viewDurationMs` and `componentViewId` to element payloads to allows us to track how long a user views a component across a single session
- Refactored `ElementSeenObserver` to support periodic heartbeats, enabling real-time reporting of active view durations rather than waiting for an exit event.
- Updated `NinetailedInsightsPlugin` to use the new `componentViewId` and latest reported duration, preventing duplicate events for the same view session.
- Replaced `jest.runAllTimers` with `jest.advanceTimersByTime` to accurately simulate heartbeats and verify that durations increase as expected.