### PR TITLE
feat(insights) More robust queue flushing

### DIFF
--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
@@ -1,7 +1,7 @@
 import { waitFor } from '@testing-library/dom';
 import { NinetailedApiClient } from '@ninetailed/experience.js-shared';
 import { NinetailedPlugin } from '@ninetailed/experience.js-plugin-analytics';
-import { Ninetailed } from '@ninetailed/experience.js';
+import { Ninetailed, PAGE_HIDDEN } from '@ninetailed/experience.js';
 import { NinetailedPrivacyPlugin } from '@ninetailed/experience.js-plugin-privacy';
 import { NinetailedInsightsPlugin } from './NinetailedInsightsPlugin';
 import { intersect } from './test-helpers/intersection-observer-test-helper';
@@ -97,6 +97,70 @@ describe('NinetailedInsightsPlugin', () => {
     jest.useRealTimers();
     await waitFor(() => {
       expect(insightsApiClientSendEventBatchesMock).not.toHaveBeenCalled();
+    });
+  });
+  it('should flush queued events on profile changes', async () => {
+    const insightsPlugin = new NinetailedInsightsPlugin();
+    const ninetailed = setupNinetailedInstance([insightsPlugin]);
+    insightsPlugin.setCredentials({
+      clientId: 'test',
+      environment: 'development',
+    });
+    await ninetailed.identify('test');
+    jest.useFakeTimers();
+    const element = document.body.appendChild(document.createElement('div'));
+    ninetailed.observeElement({
+      element,
+      variant: { id: 'variant-id-1' },
+      variantIndex: 0,
+    });
+    intersect(element, true);
+    jest.runAllTimers();
+    jest.useRealTimers();
+    expect(insightsApiClientSendEventBatchesMock).toHaveBeenCalledTimes(0);
+    await ninetailed.identify('test-2');
+    await waitFor(() => {
+      expect(insightsApiClientSendEventBatchesMock).toHaveBeenCalledTimes(1);
+      expect(
+        insightsApiClientSendEventBatchesMock.mock.calls[0][0][0].events.length
+      ).toBe(1);
+    });
+  });
+  it('should flush queued batches on page hidden even without an active profile', async () => {
+    const insightsPlugin = new NinetailedInsightsPlugin();
+    insightsPlugin.setCredentials({
+      clientId: 'test',
+      environment: 'development',
+    });
+
+    const pluginState = insightsPlugin as unknown as {
+      profile?: unknown;
+      eventsQueue: { profile: Record<string, unknown>; events: unknown[] }[];
+      [PAGE_HIDDEN]: () => void;
+    };
+
+    pluginState.eventsQueue = [
+      {
+        profile: { id: 'p-a12b3c4d5e6f7g8h9i0j' },
+        events: [{ type: 'component', componentId: 'variant-id-1' }],
+      },
+    ];
+    pluginState.profile = undefined;
+
+    pluginState[PAGE_HIDDEN]();
+
+    await waitFor(() => {
+      expect(insightsApiClientSendEventBatchesMock).toHaveBeenCalledTimes(1);
+      expect(insightsApiClientSendEventBatchesMock).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            events: expect.arrayContaining([
+              expect.objectContaining({ type: 'component' }),
+            ]),
+          }),
+        ]),
+        expect.objectContaining({ useBeacon: true })
+      );
     });
   });
   // This is a rare case and would only happen if a profile changes while the user is on the same page and the component would change e.g. from baseline to variant 1

--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.ts
@@ -375,6 +375,7 @@ export class NinetailedInsightsPlugin
 
     if (previousProfile) {
       this.createEventsBatch(previousProfile);
+      this.flushEventsQueue();
     }
 
     this.profile = profile ?? undefined;
@@ -383,11 +384,9 @@ export class NinetailedInsightsPlugin
   };
 
   public [PAGE_HIDDEN] = () => {
-    if (!this.profile) {
-      return;
+    if (this.profile) {
+      this.createEventsBatch(this.profile);
     }
-
-    this.createEventsBatch(this.profile);
 
     this.flushEventsQueue(true);
   };
@@ -410,7 +409,7 @@ export class NinetailedInsightsPlugin
   private shouldFlushEventsQueue(): boolean {
     return (
       this.eventsQueue.map(({ events }) => events).flat().length +
-        this.events.length ===
+        this.events.length >=
       NinetailedInsightsPlugin.MAX_EVENTS
     );
   }

--- a/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
@@ -11,6 +11,7 @@ import {
 } from '@ninetailed/experience.js-plugin-analytics';
 import { TestAnalyticsPlugin } from '@ninetailed/experience.js-plugin-analytics/test';
 import { Ninetailed } from './Ninetailed';
+import { PAGE_HIDDEN } from './constants';
 import {
   getObserverOf,
   intersect,
@@ -78,6 +79,14 @@ class TestElementHoverPlugin extends NinetailedPlugin {
     };
 }
 
+class TestPageHiddenPlugin extends NinetailedPlugin {
+  public name = 'ninetailed:test-page-hidden';
+  public onPageHiddenMock = jest.fn();
+  public [PAGE_HIDDEN] = () => {
+    this.onPageHiddenMock();
+  };
+}
+
 describe('Ninetailed core class', () => {
   let ninetailed: Ninetailed;
   let apiClient: NinetailedApiClient;
@@ -97,6 +106,15 @@ describe('Ninetailed core class', () => {
         new NinetailedApiClient({ clientId: 'test' })
       );
       expect(instance).toBeInstanceOf(Ninetailed);
+    });
+    it('should dispatch page hidden events on pagehide and beforeunload', async () => {
+      const pageHiddenPlugin = new TestPageHiddenPlugin();
+      mockProfile([pageHiddenPlugin]);
+      window.dispatchEvent(new Event('pagehide'));
+      window.dispatchEvent(new Event('beforeunload'));
+      await waitFor(() => {
+        expect(pageHiddenPlugin.onPageHiddenMock).toHaveBeenCalledTimes(2);
+      });
     });
   });
   describe('Sending of events', () => {

--- a/packages/sdks/javascript/src/lib/Ninetailed.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.ts
@@ -1124,15 +1124,22 @@ export class Ninetailed implements NinetailedInstance {
   }
 
   private onVisibilityChange = () => {
-    if (typeof document === 'undefined') {
+    if (typeof document === 'undefined' || typeof window === 'undefined') {
       return;
     }
 
+    const dispatchPageHidden = () => {
+      this.elementHoverObserver.flushActiveHovers();
+      this.instance.dispatch({ type: PAGE_HIDDEN });
+    };
+
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'hidden') {
-        this.elementHoverObserver.flushActiveHovers();
-        this.instance.dispatch({ type: PAGE_HIDDEN });
+        dispatchPageHidden();
       }
     });
+
+    window.addEventListener('pagehide', dispatchPageHidden);
+    window.addEventListener('beforeunload', dispatchPageHidden);
   };
 }


### PR DESCRIPTION
Currently, the Insights event queue is only flushed when a page changes visibility. This means that events can be lost for any other action that may move the page out of context. In addition to the existing `visibilitychange` event, we will also listen for the `pagehide` and `beforeunload` events for the purpose of flushing the queue.

This PR also further strengthens Insights queue handling by ensuring events that previously had a profile will still be queued in the event of profile loss, and that events will be queued when they _exceed_ the maximum limit and not only when they _meet_ the limit.

[[ES-70](https://contentful.atlassian.net/browse/ES-70)]

[ES-70]: https://contentful.atlassian.net/browse/ES-70?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ