### PR TITLE
chore: deprecate useSDKEvaluation and warn when enabled

### DIFF
--- a/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
@@ -2,6 +2,7 @@ import { waitFor } from '@testing-library/dom';
 import {
   FEATURES,
   NinetailedApiClient,
+  logger,
 } from '@ninetailed/experience.js-shared';
 import {
   ElementClickedPayload,
@@ -100,6 +101,43 @@ describe('Ninetailed core class', () => {
         clientId: 'test',
       });
       expect(instance).toBeInstanceOf(Ninetailed);
+    });
+    it('should warn when useSDKEvaluation is enabled', () => {
+      const warnSpy = jest
+        .spyOn(logger, 'warn')
+        .mockImplementation(() => undefined);
+
+      new Ninetailed(
+        {
+          clientId: 'test',
+        },
+        {
+          useSDKEvaluation: true,
+        }
+      );
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        "You are using the 'useSDKEvaluation' option. This feature is deprecated and will be removed in a future major release."
+      );
+    });
+    it('should not warn when useSDKEvaluation is disabled', () => {
+      const warnSpy = jest
+        .spyOn(logger, 'warn')
+        .mockImplementation(() => undefined);
+
+      new Ninetailed({
+        clientId: 'test',
+      });
+      new Ninetailed(
+        {
+          clientId: 'test',
+        },
+        {
+          useSDKEvaluation: false,
+        }
+      );
+
+      expect(warnSpy).not.toHaveBeenCalled();
     });
     it('should be able to create a new instance with a outside instantiated NinetailedApiClient', () => {
       const instance = new Ninetailed(

--- a/packages/sdks/javascript/src/lib/Ninetailed.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.ts
@@ -121,6 +121,9 @@ type Options = {
   onInitProfileId?: OnInitProfileId;
   buildClientContext?: () => NinetailedRequestContext;
   storageImpl?: Storage;
+  /**
+   * @deprecated This option is deprecated and will be removed in a future major version.
+   */
   useSDKEvaluation?: boolean;
 };
 
@@ -181,7 +184,9 @@ export class Ninetailed implements NinetailedInstance {
   public readonly logger: Logger;
 
   private readonly componentViewTrackingThreshold: number;
-
+  /**
+   * @deprecated This option is deprecated and will be removed in a future major version.
+   */
   private readonly useSDKEvaluation: boolean;
 
   public readonly eventBuilder: EventBuilder;
@@ -214,6 +219,12 @@ export class Ninetailed implements NinetailedInstance {
     this.logger = logger;
 
     this.useSDKEvaluation = useSDKEvaluation;
+
+    if (useSDKEvaluation) {
+      logger.warn(
+        "You are using the 'useSDKEvaluation' option. This feature is deprecated and will be removed in a future major release."
+      );
+    }
 
     if (ninetailedApiClientInstanceOrOptions instanceof NinetailedApiClient) {
       this.apiClient = ninetailedApiClientInstanceOrOptions;

--- a/packages/sdks/react/src/lib/NinetailedProvider.tsx
+++ b/packages/sdks/react/src/lib/NinetailedProvider.tsx
@@ -30,7 +30,9 @@ export type NinetailedProviderInstantiationProps = {
   buildClientContext?: () => NinetailedRequestContext;
   onInitProfileId?: OnInitProfileId;
   storageImpl?: Storage;
-
+  /**
+   * @deprecated This option is deprecated and will be removed in a future major version.
+   */
   useSDKEvaluation?: boolean;
 };
 


### PR DESCRIPTION
- Deprecates useSDKEvaluation in the JavaScript SDK options and React provider props with `@deprecated` annotations.
- Adds a runtime warning in Ninetailed when useSDKEvaluation is enabled (true) to notify users the feature is deprecated and will be removed in a future major release.

This feature has already been removed from the documentation page. 