### PR TITLE
fix(sdks-nodejs): use native fetch

### DIFF
--- a/packages/sdks/nodejs/package.json
+++ b/packages/sdks/nodejs/package.json
@@ -4,7 +4,6 @@
   "type": "commonjs",
   "description": "Ninetailed SDK for Node.js",
   "dependencies": {
-    "node-fetch": "2",
     "uuid": "9.0.0",
     "@ninetailed/experience.js-shared": "*",
     "jest-fetch-mock": "3.0.3",

--- a/packages/sdks/nodejs/src/lib/Client/Client.ts
+++ b/packages/sdks/nodejs/src/lib/Client/Client.ts
@@ -3,7 +3,6 @@ import type { Properties } from '@ninetailed/experience.js-shared';
 import {
   buildIdentifyEvent,
   buildTrackEvent,
-  FetchImpl,
   IdentifyEvent,
   NinetailedApiClient as BaseNinetailedAPIClient,
   NinetailedApiClientOptions,
@@ -12,7 +11,6 @@ import {
   Traits,
   UpsertManyProfilesRequestOptions,
 } from '@ninetailed/experience.js-shared';
-import fetch from 'node-fetch';
 
 type SendEventOptions = {
   anonymousId?: string;
@@ -21,7 +19,7 @@ type SendEventOptions = {
 
 export class NinetailedAPIClient extends BaseNinetailedAPIClient {
   constructor(options: NinetailedApiClientOptions) {
-    super({ ...options, fetchImpl: fetch as unknown as FetchImpl });
+    super(options);
   }
 
   public createIdentifyEvent(

--- a/packages/sdks/nodejs/test/nodejs-client.spec.ts
+++ b/packages/sdks/nodejs/test/nodejs-client.spec.ts
@@ -8,6 +8,37 @@ describe('Node.js client', () => {
       environment: process.env.NINETAILED_ENVIRONMENT,
     });
   });
+  it('Should use a custom fetch implementation when provided', async () => {
+    const fetchImpl = jest.fn(async () => {
+      return {
+        ok: false,
+        status: 418,
+        statusText: "I'm a teapot",
+        headers: {
+          get: jest.fn(() => null),
+        },
+      } as unknown as Response;
+    });
+
+    client = new NinetailedAPIClient({
+      clientId: 'client-id',
+      environment: 'main',
+      url: 'https://example.com',
+      fetchImpl,
+    });
+
+    await expect(client.getProfile('profile-id')).rejects.toThrow(
+      'Get Profile request failed with status'
+    );
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://example.com/v2/organizations/client-id/environments/main/profiles/profile-id',
+      expect.objectContaining({
+        method: 'GET',
+        timeout: 3000,
+      })
+    );
+  });
   it('Should send identify event and return a profile promise', async () => {
     fetchMock.dontMock();
     const response = client.sendIdentifyEvent('testUser', {

--- a/packages/tests/generated-packages/src/lib/__snapshots__/generated-package-json.spec.ts.snap
+++ b/packages/tests/generated-packages/src/lib/__snapshots__/generated-package-json.spec.ts.snap
@@ -471,7 +471,6 @@ Object {
     "@ninetailed/experience.js-shared": "*",
     "jest-fetch-mock": "3.0.3",
     "jsonc-eslint-parser": "3.0.0",
-    "node-fetch": "2",
     "uuid": "9.0.0",
   },
   "description": "Ninetailed SDK for Node.js",


### PR DESCRIPTION
## Summary

This should fix potential issues with consumers using node 24.17 with our node SDK.

- Remove the hardcoded node-fetch@2 implementation from @ninetailed/experience.js-node.
- Let the shared API client use the runtime/native fetch by default and preserve caller-provided fetchImpl overrides.
- Add a regression test for fetchImpl injection and update generated package snapshots.

## Context
- Slack: https://contentful.slack.com/archives/C0BD3PCQRL2/p1782383885595159
- This avoids node-fetch@2 false premature-close failures under Node 24.17 keep-alive socket changes.

## Testing
- corepack pnpm nx test sdks-nodejs --skip-nx-cache
- corepack pnpm nx build sdks-nodejs --skip-nx-cache
- corepack pnpm run build-all:except-playgrounds
- corepack pnpm exec jest -c packages/tests/generated-packages/jest.config.js --runInBand

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default HTTP stack for all Node SDK API calls; behavior should align with modern Node but differs from the previous node-fetch@2 path on older runtimes without global fetch.
> 
> **Overview**
> The Node SDK no longer pins **`node-fetch@2`** or injects it into the shared API client. **`NinetailedAPIClient`** now forwards constructor options unchanged, so HTTP uses the runtime’s **native `fetch`** (as the shared client already defaults to) while **`fetchImpl`** overrides from callers still apply.
> 
> This targets **Node 24.17** issues where `node-fetch@2` could hit premature-close errors under keep-alive socket changes. A regression test asserts custom **`fetchImpl`** is used for profile requests, and generated **`package.json`** snapshots drop the `node-fetch` dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11bb2918e17a59e076e631271a020cf77e77a192. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->