### PR TITLE
chore(sdks-nodejs): declare Node engine

### DIFF
--- a/packages/sdks/nodejs/package.json
+++ b/packages/sdks/nodejs/package.json
@@ -3,6 +3,9 @@
   "version": "7.6.0-beta.1",
   "type": "commonjs",
   "description": "Ninetailed SDK for Node.js",
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
     "node-fetch": "2",
     "uuid": "9.0.0",


### PR DESCRIPTION
## Summary
- declare Node.js >=20 in the Node SDK package engines field

For context, see https://contentful.slack.com/archives/C08UR6P9D0X/p1782390202395029?thread_ts=1782384762.812749&cid=C08UR6P9D0X

## Validation
- node -e "JSON.parse(require('fs').readFileSync('packages/sdks/nodejs/package.json','utf8')); console.log('valid package json')"
- commit hook: nx format:write --files=packages/sdks/nodejs/package.json
- commit hook: nx affected:lint --files=packages/sdks/nodejs/package.json

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0729f988caaa878c5485dfb6bffa4ccd9d0d9c0e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->