### PR TITLE
test(generated-packages): refresh Node SDK snapshot

### DIFF
--- a/.github/workflows/lint_build_test_all.yaml
+++ b/.github/workflows/lint_build_test_all.yaml
@@ -104,6 +104,12 @@ jobs:
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
+      - name: Generated package snapshots 🧪
+        run: >
+          doppler run --mount .env -- pnpm nx run tests-generated-packages:test
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+
   build:
     name: Build 📦
     runs-on: ubuntu-latest

--- a/packages/tests/generated-packages/src/lib/__snapshots__/generated-package-json.spec.ts.snap
+++ b/packages/tests/generated-packages/src/lib/__snapshots__/generated-package-json.spec.ts.snap
@@ -474,6 +474,9 @@ Object {
     "uuid": "9.0.0",
   },
   "description": "Ninetailed SDK for Node.js",
+  "engines": Object {
+    "node": ">=20",
+  },
   "keywords": Array [
     "nodejs",
     "ninetailed",


### PR DESCRIPTION
## Summary

test failed on publish: https://github.com/ninetailed-inc/experience.js/actions/runs/28170383192

This PR fixes it.

- refresh the generated package snapshot for the Node SDK engines field
- run the generated package snapshot test explicitly in PR CI so release-only drift is caught earlier

## Validation
- corepack pnpm exec nx run sdks-nodejs:build --skip-nx-cache
- corepack pnpm exec nx run tests-generated-packages:test --excludeTaskDependencies --skip-nx-cache
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/lint_build_test_all.yaml'); puts 'valid yaml'"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Jest snapshots and CI workflow steps; no application or SDK runtime logic is modified in this diff.
> 
> **Overview**
> Fixes a **publish-time failure** where generated `package.json` snapshots no longer matched the built Node SDK output.
> 
> The snapshot for `@ninetailed/experience.js-node` now includes **`engines.node: ">=20"`**, reflecting what the Node SDK build emits into `dist`.
> 
> PR CI adds a dedicated step that always runs **`tests-generated-packages:test`** (via Doppler), in addition to `nx affected --target=test`, so snapshot drift is caught on pull requests instead of only at release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f80007a8dcdae218c2af5c70bcb6a79f0d5c906. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->