### PR TITLE
security(ci): restrict GITHUB_TOKEN permissions in publish workflow [ACT-2406] [ACT-2407] [ACT-2408] [ACT-2409] [ACT-2410]

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -72,6 +72,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      actions: read # required by nrwl/nx-set-shas to query the Actions API
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -106,6 +106,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -142,6 +142,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,6 +8,8 @@ jobs:
     name: pnpm install 🛠️
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -70,6 +70,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Adds explicit `permissions` blocks to the 5 jobs in `.github/workflows/publish.yaml` that were missing them. This restricts the default `GITHUB_TOKEN` scope to the minimum required per job, resolving 5 CodeQL security findings.

The `publish` job already had correct permissions (`id-token: write`, `contents: read`, `actions: read`) and is unchanged.

## Permissions per job

| Job | `contents` | `actions` | Reason |
|-----|------------|-----------|--------|
| `setup` | `read` | — | checkout only |
| `build` | `read` | — | checkout only |
| `lint` | `read` | `read` | `nrwl/nx-set-shas` queries the Actions API ([docs](https://github.com/nrwl/nx-set-shas#permissions-in-v2)) |
| `tests` | `read` | — | checkout only |
| `license-check` | `read` | — | checkout only |

> **Note:** `lint` needs `actions: read` in addition to `contents: read` because `nrwl/nx-set-shas@v3` calls the GitHub Actions API to find the last successful workflow run. This matches the pattern already used in `.github/workflows/lint_build_test_all.yaml`.

## Tickets

- [ACT-2410](https://contentful.atlassian.net/browse/ACT-2410) — `setup` job
- [ACT-2409](https://contentful.atlassian.net/browse/ACT-2409) — `build` job
- [ACT-2408](https://contentful.atlassian.net/browse/ACT-2408) — `lint` job (+ `actions: read` follow-up)
- [ACT-2407](https://contentful.atlassian.net/browse/ACT-2407) — `tests` job
- [ACT-2406](https://contentful.atlassian.net/browse/ACT-2406) — `license-check` job

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permission scoping with no application or runtime behavior changes; lint explicitly keeps the Actions API access nx-set-shas needs.
> 
> **Overview**
> Tightens **least-privilege** for the release **publish** workflow by giving each previously unrestricted job an explicit `permissions` block instead of the default broad `GITHUB_TOKEN` scope (addressing CodeQL findings).
> 
> **`setup`**, **`build`**, **`tests`**, and **`license-check`** now only grant `contents: read`. **`lint`** adds `contents: read` plus **`actions: read`** so `nrwl/nx-set-shas` can query the Actions API. The **`publish`** job’s existing permissions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdee1f74bbe5ce06cb110f4039d8cae275d6ffae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[ACT-2410]: https://contentful.atlassian.net/browse/ACT-2410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ