### PR TITLE
chore: replace `view` & `hover` heartbeats with `start`/`end` events

### DIFF
--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
@@ -340,7 +340,7 @@ describe('NinetailedInsightsPlugin', () => {
     expect(viewIds.size).toBe(2);
     expect(Math.max(...durations)).toBeLessThan(4_000);
   });
-  it('should flush component view heartbeats with sendBeacon on page hide', async () => {
+  it('should flush the ended component view session with sendBeacon on page hide', async () => {
     const insightsPlugin = new NinetailedInsightsPlugin();
     const ninetailed = setupNinetailedInstance([insightsPlugin]);
     insightsPlugin.setCredentials({
@@ -363,6 +363,11 @@ describe('NinetailedInsightsPlugin', () => {
       value: 'hidden',
     });
     document.dispatchEvent(new Event('visibilitychange'));
+    // The visibilitychange handler defers its PAGE_HIDDEN dispatch by a
+    // setTimeout(0) tick so the async view-session-end dispatch chain can
+    // settle first; flush that pending fake timer before switching modes,
+    // otherwise it's abandoned and never fires.
+    jest.runOnlyPendingTimers();
     jest.useRealTimers();
 
     await waitFor(() => {

--- a/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
+++ b/packages/plugins/insights/src/lib/NinetailedInsightsPlugin.spec.ts
@@ -185,14 +185,12 @@ describe('NinetailedInsightsPlugin', () => {
       });
     }
     intersect(element, true);
-
-    // Run a bounded number of heartbeats to avoid an unbounded timer loop.
-    for (let i = 0; i < 25; i++) {
-      jest.runOnlyPendingTimers();
-    }
+    jest.advanceTimersByTime(2_100);
     intersect(element, false);
-    jest.runOnlyPendingTimers();
     jest.useRealTimers();
+
+    expect(insightsApiClientSendEventBatchesMock).toHaveBeenCalledTimes(0);
+    await ninetailed.identify('test-2');
     await waitFor(() => {
       expect(insightsApiClientSendEventBatchesMock).toHaveBeenCalledTimes(1);
     });

--- a/packages/sdks/javascript/src/lib/ElementHoverObserver.ts
+++ b/packages/sdks/javascript/src/lib/ElementHoverObserver.ts
@@ -5,21 +5,13 @@ export type ElementHoverObserverOptions = {
     hoverId: string
   ) => void;
   componentHoverTrackingThreshold?: number;
-  heartbeatIntervalMs?: number;
-  minimumHeartbeatIncrementMs?: number;
 };
 
 type ElementHoverSession = {
   hoverId: string;
   hoverStartTimestamp: number;
-  lastReportedMs: number;
-};
-
-type EmitHoverIfNeededParams = {
-  element: Element;
-  hoverSession: ElementHoverSession;
-  now: number;
-  forceReport: boolean;
+  startEmitted: boolean;
+  startTimer: number | null;
 };
 
 export class ElementHoverObserver {
@@ -31,21 +23,14 @@ export class ElementHoverObserver {
     }
   >;
   private _activeHoverSessions: Map<Element, ElementHoverSession>;
-  private _heartbeatTimer: number | null;
 
   private readonly componentHoverTrackingThreshold: number;
-  private readonly heartbeatIntervalMs: number;
-  private readonly minimumHeartbeatIncrementMs: number;
 
   constructor(private _options: ElementHoverObserverOptions) {
     this._elementHandlers = new WeakMap();
     this._activeHoverSessions = new Map();
-    this._heartbeatTimer = null;
     this.componentHoverTrackingThreshold =
       _options.componentHoverTrackingThreshold ?? 2000;
-    this.heartbeatIntervalMs = _options.heartbeatIntervalMs ?? 2000;
-    this.minimumHeartbeatIncrementMs =
-      _options.minimumHeartbeatIncrementMs ?? 1000;
   }
 
   public observe(element: Element) {
@@ -58,17 +43,11 @@ export class ElementHoverObserver {
         return;
       }
 
-      this._activeHoverSessions.set(element, {
-        hoverId: crypto.randomUUID(),
-        hoverStartTimestamp: Date.now(),
-        lastReportedMs: 0,
-      });
-
-      this.startHeartbeatIfNeeded();
+      this.startSession(element);
     };
 
     const onMouseLeave = () => {
-      this.endHoverSession(element, true);
+      this.endSession(element, Date.now());
     };
 
     element.addEventListener('mouseenter', onMouseEnter);
@@ -91,101 +70,70 @@ export class ElementHoverObserver {
     element.removeEventListener('mouseleave', handlers.mouseleave);
 
     this._elementHandlers.delete(element);
-    this.endHoverSession(element, false);
+    this.endSession(element, Date.now());
   }
 
-  public flushActiveHovers() {
+  /**
+   * Ends every active hover session immediately (e.g. on tab hide) so a
+   * final hover event is emitted rather than left dangling.
+   */
+  public endActiveSessions() {
     const now = Date.now();
 
-    this._activeHoverSessions.forEach((hoverSession, element) => {
-      this.emitHoverIfNeeded({
-        element,
-        hoverSession,
-        now,
-        forceReport: true,
-      });
+    Array.from(this._activeHoverSessions.keys()).forEach((element) => {
+      this.endSession(element, now);
     });
-
-    this._activeHoverSessions.clear();
-    this.stopHeartbeatIfIdle();
   }
 
-  private startHeartbeatIfNeeded() {
-    if (this._heartbeatTimer !== null || this._activeHoverSessions.size === 0) {
+  private startSession(element: Element) {
+    const now = Date.now();
+    const session: ElementHoverSession = {
+      hoverId: crypto.randomUUID(),
+      hoverStartTimestamp: now,
+      startEmitted: false,
+      startTimer: null,
+    };
+
+    this._activeHoverSessions.set(element, session);
+
+    if (this.componentHoverTrackingThreshold <= 0) {
+      this.emitStart(element, session);
       return;
     }
 
-    this._heartbeatTimer = window.setInterval(() => {
-      const now = Date.now();
-
-      this._activeHoverSessions.forEach((hoverSession, element) => {
-        this.emitHoverIfNeeded({
-          element,
-          hoverSession,
-          now,
-          forceReport: false,
-        });
-      });
-    }, this.heartbeatIntervalMs);
+    session.startTimer = window.setTimeout(() => {
+      session.startTimer = null;
+      this.emitStart(element, session);
+    }, this.componentHoverTrackingThreshold);
   }
 
-  private stopHeartbeatIfIdle() {
-    if (this._activeHoverSessions.size > 0 || this._heartbeatTimer === null) {
+  private emitStart(element: Element, session: ElementHoverSession) {
+    if (session.startEmitted) {
       return;
     }
 
-    window.clearInterval(this._heartbeatTimer);
-    this._heartbeatTimer = null;
+    session.startEmitted = true;
+    this._options.onElementHover(element, 0, session.hoverId);
   }
 
-  private endHoverSession(element: Element, emitFinalHeartbeat: boolean) {
-    const hoverSession = this._activeHoverSessions.get(element);
+  private endSession(element: Element, now: number) {
+    const session = this._activeHoverSessions.get(element);
 
-    if (!hoverSession) {
-      this.stopHeartbeatIfIdle();
+    if (!session) {
       return;
     }
 
-    if (emitFinalHeartbeat) {
-      this.emitHoverIfNeeded({
-        element,
-        hoverSession,
-        now: Date.now(),
-        forceReport: true,
-      });
+    if (session.startTimer !== null) {
+      window.clearTimeout(session.startTimer);
     }
 
     this._activeHoverSessions.delete(element);
-    this.stopHeartbeatIfIdle();
-  }
 
-  private emitHoverIfNeeded({
-    element,
-    hoverSession,
-    now,
-    forceReport,
-  }: EmitHoverIfNeededParams) {
-    const hoverDurationMs = now - hoverSession.hoverStartTimestamp;
-
-    if (hoverDurationMs < this.componentHoverTrackingThreshold) {
+    if (!session.startEmitted) {
       return;
     }
 
-    const durationDelta = hoverDurationMs - hoverSession.lastReportedMs;
-
-    if (durationDelta <= 0) {
-      return;
-    }
-
-    if (!forceReport && durationDelta < this.minimumHeartbeatIncrementMs) {
-      return;
-    }
-
-    this._options.onElementHover(
-      element,
-      hoverDurationMs,
-      hoverSession.hoverId
-    );
-    hoverSession.lastReportedMs = hoverDurationMs;
+    const hoverDurationMs = now - session.hoverStartTimestamp;
+    this._options.onElementHover(element, hoverDurationMs, session.hoverId);
   }
 }

--- a/packages/sdks/javascript/src/lib/ElementHoverObserver.ts
+++ b/packages/sdks/javascript/src/lib/ElementHoverObserver.ts
@@ -15,7 +15,7 @@ type ElementHoverSession = {
 };
 
 export class ElementHoverObserver {
-  private _elementHandlers: WeakMap<
+  private _elementHandlers: Map<
     Element,
     {
       mouseenter: EventListener;
@@ -27,7 +27,7 @@ export class ElementHoverObserver {
   private readonly componentHoverTrackingThreshold: number;
 
   constructor(private _options: ElementHoverObserverOptions) {
-    this._elementHandlers = new WeakMap();
+    this._elementHandlers = new Map();
     this._activeHoverSessions = new Map();
     this.componentHoverTrackingThreshold =
       _options.componentHoverTrackingThreshold ?? 2000;
@@ -57,6 +57,13 @@ export class ElementHoverObserver {
       mouseenter: onMouseEnter,
       mouseleave: onMouseLeave,
     });
+
+    // The pointer may already be over the element when we start observing it
+    // (e.g. a React re-render unobserves and re-observes the same element
+    // while the cursor hasn't moved), in which case mouseenter never fires.
+    if (element.matches(':hover')) {
+      this.startSession(element);
+    }
   }
 
   public unobserve(element: Element) {
@@ -82,6 +89,23 @@ export class ElementHoverObserver {
 
     Array.from(this._activeHoverSessions.keys()).forEach((element) => {
       this.endSession(element, now);
+    });
+  }
+
+  /**
+   * Restarts a hover session for elements the pointer is still over after a
+   * tab returns to the foreground. Ending sessions on tab hide doesn't fire
+   * mouseleave, so mouseenter won't fire again until the pointer actually
+   * leaves and re-enters. Produces a fresh hoverId.
+   */
+  public resumeActiveSessions() {
+    this._elementHandlers.forEach((_handlers, element) => {
+      if (
+        !this._activeHoverSessions.has(element) &&
+        element.matches(':hover')
+      ) {
+        this.startSession(element);
+      }
     });
   }
 

--- a/packages/sdks/javascript/src/lib/ElementSeenObserver.ts
+++ b/packages/sdks/javascript/src/lib/ElementSeenObserver.ts
@@ -73,7 +73,10 @@ export class ElementSeenObserver {
       });
     } else if (!viewState.delays.has(delay)) {
       viewState.delays.add(delay);
-      this.scheduleDelayStart(element, viewState, delay);
+
+      if (viewState.viewId !== null) {
+        this.scheduleDelayStart(element, viewState, delay, viewState.viewId);
+      }
     }
 
     this._intersectionObserver?.observe(element);
@@ -126,20 +129,22 @@ export class ElementSeenObserver {
     viewState: ElementViewState,
     now: number
   ) {
-    viewState.viewId = crypto.randomUUID();
+    const viewId = crypto.randomUUID();
+    viewState.viewId = viewId;
     viewState.sessionStartTimestamp = now;
     viewState.startedDelays = new Set();
     viewState.pendingStartTimers = new Map();
 
     viewState.delays.forEach((delay) => {
-      this.scheduleDelayStart(element, viewState, delay);
+      this.scheduleDelayStart(element, viewState, delay, viewId);
     });
   }
 
   private scheduleDelayStart(
     element: Element,
     viewState: ElementViewState,
-    delay: number
+    delay: number,
+    viewId: string
   ) {
     if (viewState.sessionStartTimestamp === null) {
       return;
@@ -149,13 +154,13 @@ export class ElementSeenObserver {
     const remaining = delay - elapsed;
 
     if (remaining <= 0) {
-      this.emitStart(element, viewState, delay);
+      this.emitStart(element, viewState, delay, viewId);
       return;
     }
 
     const timerId = window.setTimeout(() => {
       viewState.pendingStartTimers.delete(delay);
-      this.emitStart(element, viewState, delay);
+      this.emitStart(element, viewState, delay, viewId);
     }, remaining);
 
     viewState.pendingStartTimers.set(delay, timerId);
@@ -164,7 +169,8 @@ export class ElementSeenObserver {
   private emitStart(
     element: Element,
     viewState: ElementViewState,
-    delay: number
+    delay: number,
+    viewId: string
   ) {
     if (
       viewState.sessionStartTimestamp === null ||
@@ -174,7 +180,7 @@ export class ElementSeenObserver {
     }
 
     viewState.startedDelays.add(delay);
-    this._options.onElementSeen(element, delay, 0, viewState.viewId as string);
+    this._options.onElementSeen(element, delay, 0, viewId);
   }
 
   private endSession(
@@ -187,12 +193,12 @@ export class ElementSeenObserver {
     });
     viewState.pendingStartTimers.clear();
 
-    if (viewState.sessionStartTimestamp === null) {
+    if (viewState.sessionStartTimestamp === null || viewState.viewId === null) {
       return;
     }
 
     const viewDurationMs = now - viewState.sessionStartTimestamp;
-    const viewId = viewState.viewId as string;
+    const viewId = viewState.viewId;
 
     viewState.startedDelays.forEach((delay) => {
       this._options.onElementSeen(element, delay, viewDurationMs, viewId);

--- a/packages/sdks/javascript/src/lib/ElementSeenObserver.ts
+++ b/packages/sdks/javascript/src/lib/ElementSeenObserver.ts
@@ -7,51 +7,25 @@ export type ElementSeenObserverOptions = {
     viewDurationMs: number,
     viewId: string
   ) => void;
-  heartbeatIntervalMs?: number;
-  extendedHeartbeatIntervalMs?: number;
-  extendedHeartbeatThresholdMs?: number;
-  minimumHeartbeatIncrementMs?: number;
 };
 
 export type { ObserveOptions } from './types/ObserveOptions';
 
 type ElementViewState = {
-  viewId: string;
   delays: Set<number>;
-  enterTimestamp: number | null;
-  accumulatedVisibleDurationMs: number;
-  lastReportedDurationByDelay: Map<number, number>;
-};
-
-type EmitViewIfNeededParams = {
-  element: Element;
-  viewState: ElementViewState;
-  now: number;
-  forceReport: boolean;
+  isIntersecting: boolean;
+  viewId: string | null;
+  sessionStartTimestamp: number | null;
+  startedDelays: Set<number>;
+  pendingStartTimers: Map<number, number>;
 };
 
 export class ElementSeenObserver {
   private _intersectionObserver?: IntersectionObserver;
   private _elementViewState: Map<Element, ElementViewState>;
-  private _heartbeatTimer: number | null;
-  private _scheduledHeartbeatIntervalMs: number | null;
-
-  private readonly heartbeatIntervalMs: number;
-  private readonly extendedHeartbeatIntervalMs: number;
-  private readonly extendedHeartbeatThresholdMs: number;
-  private readonly minimumHeartbeatIncrementMs: number;
 
   constructor(private _options: ElementSeenObserverOptions) {
     this._elementViewState = new Map();
-    this._heartbeatTimer = null;
-    this._scheduledHeartbeatIntervalMs = null;
-    this.heartbeatIntervalMs = _options.heartbeatIntervalMs ?? 2000;
-    this.extendedHeartbeatIntervalMs =
-      _options.extendedHeartbeatIntervalMs ?? 10000;
-    this.extendedHeartbeatThresholdMs =
-      _options.extendedHeartbeatThresholdMs ?? 10000;
-    this.minimumHeartbeatIncrementMs =
-      _options.minimumHeartbeatIncrementMs ?? 1000;
 
     if (typeof IntersectionObserver !== 'undefined') {
       this._intersectionObserver = new IntersectionObserver(
@@ -71,25 +45,16 @@ export class ElementSeenObserver {
         return;
       }
 
+      viewState.isIntersecting = isIntersecting;
+
       if (isIntersecting) {
-        if (viewState.enterTimestamp === null) {
-          const hasPreviousViewSession =
-            viewState.accumulatedVisibleDurationMs > 0 ||
-            viewState.lastReportedDurationByDelay.size > 0;
-
-          if (hasPreviousViewSession) {
-            viewState.viewId = crypto.randomUUID();
-            viewState.accumulatedVisibleDurationMs = 0;
-            viewState.lastReportedDurationByDelay.clear();
-          }
-
-          viewState.enterTimestamp = now;
-          this.startHeartbeatIfNeeded();
+        if (viewState.sessionStartTimestamp === null) {
+          this.startSession(target, viewState, now);
         }
         return;
       }
 
-      this.stopTrackingVisibleTime(target, true, now);
+      this.endSession(target, viewState, now);
     });
   }
 
@@ -99,207 +64,142 @@ export class ElementSeenObserver {
 
     if (!viewState) {
       this._elementViewState.set(element, {
-        viewId: crypto.randomUUID(),
         delays: new Set([delay]),
-        enterTimestamp: null,
-        accumulatedVisibleDurationMs: 0,
-        lastReportedDurationByDelay: new Map(),
+        isIntersecting: false,
+        viewId: null,
+        sessionStartTimestamp: null,
+        startedDelays: new Set(),
+        pendingStartTimers: new Map(),
       });
-    } else {
+    } else if (!viewState.delays.has(delay)) {
       viewState.delays.add(delay);
+      this.scheduleDelayStart(element, viewState, delay);
     }
 
     this._intersectionObserver?.observe(element);
   }
 
   public unobserve(element: Element) {
-    this.stopTrackingVisibleTime(element, true, Date.now());
+    const viewState = this._elementViewState.get(element);
+
+    if (viewState) {
+      this.endSession(element, viewState, Date.now());
+    }
+
     this._elementViewState.delete(element);
     this._intersectionObserver?.unobserve(element);
-    this.stopHeartbeatIfIdle();
   }
 
-  public flushActiveViews() {
+  /**
+   * Ends every active view session immediately (e.g. on tab hide) so a final
+   * view event is emitted rather than left dangling.
+   */
+  public endActiveSessions() {
     const now = Date.now();
 
     this._elementViewState.forEach((viewState, element) => {
-      if (viewState.enterTimestamp === null) {
-        return;
+      if (viewState.sessionStartTimestamp !== null) {
+        this.endSession(element, viewState, now);
       }
-
-      this.emitViewIfNeeded({
-        element,
-        viewState,
-        now,
-        forceReport: true,
-      });
     });
   }
 
-  private runHeartbeat = () => {
-    this._heartbeatTimer = null;
-    this._scheduledHeartbeatIntervalMs = null;
-
+  /**
+   * Restarts a view session for elements that are still intersecting after
+   * a tab returns to the foreground. Produces a fresh viewId.
+   */
+  public resumeActiveSessions() {
     const now = Date.now();
 
     this._elementViewState.forEach((viewState, element) => {
-      if (viewState.enterTimestamp === null) {
-        return;
+      if (
+        viewState.isIntersecting &&
+        viewState.sessionStartTimestamp === null
+      ) {
+        this.startSession(element, viewState, now);
       }
-
-      this.emitViewIfNeeded({
-        element,
-        viewState,
-        now,
-        forceReport: false,
-      });
     });
+  }
 
-    this.startHeartbeatIfNeeded();
-  };
+  private startSession(
+    element: Element,
+    viewState: ElementViewState,
+    now: number
+  ) {
+    viewState.viewId = crypto.randomUUID();
+    viewState.sessionStartTimestamp = now;
+    viewState.startedDelays = new Set();
+    viewState.pendingStartTimers = new Map();
 
-  private startHeartbeatIfNeeded() {
-    if (this.getActiveViewCount() === 0) {
-      this.stopHeartbeatIfIdle();
+    viewState.delays.forEach((delay) => {
+      this.scheduleDelayStart(element, viewState, delay);
+    });
+  }
+
+  private scheduleDelayStart(
+    element: Element,
+    viewState: ElementViewState,
+    delay: number
+  ) {
+    if (viewState.sessionStartTimestamp === null) {
       return;
     }
 
-    const now = Date.now();
-    const heartbeatIntervalMs = this.getHeartbeatIntervalMs(now);
+    const elapsed = Date.now() - viewState.sessionStartTimestamp;
+    const remaining = delay - elapsed;
 
+    if (remaining <= 0) {
+      this.emitStart(element, viewState, delay);
+      return;
+    }
+
+    const timerId = window.setTimeout(() => {
+      viewState.pendingStartTimers.delete(delay);
+      this.emitStart(element, viewState, delay);
+    }, remaining);
+
+    viewState.pendingStartTimers.set(delay, timerId);
+  }
+
+  private emitStart(
+    element: Element,
+    viewState: ElementViewState,
+    delay: number
+  ) {
     if (
-      this._heartbeatTimer !== null &&
-      this._scheduledHeartbeatIntervalMs === heartbeatIntervalMs
+      viewState.sessionStartTimestamp === null ||
+      viewState.startedDelays.has(delay)
     ) {
       return;
     }
 
-    if (this._heartbeatTimer !== null) {
-      window.clearTimeout(this._heartbeatTimer);
-    }
-
-    this._scheduledHeartbeatIntervalMs = heartbeatIntervalMs;
-    this._heartbeatTimer = window.setTimeout(
-      this.runHeartbeat,
-      heartbeatIntervalMs
-    );
+    viewState.startedDelays.add(delay);
+    this._options.onElementSeen(element, delay, 0, viewState.viewId as string);
   }
 
-  private stopHeartbeatIfIdle() {
-    if (this.getActiveViewCount() > 0 || this._heartbeatTimer === null) {
-      return;
-    }
-
-    window.clearTimeout(this._heartbeatTimer);
-    this._heartbeatTimer = null;
-    this._scheduledHeartbeatIntervalMs = null;
-  }
-
-  private getActiveViewCount() {
-    let activeViewCount = 0;
-
-    this._elementViewState.forEach((viewState) => {
-      if (viewState.enterTimestamp !== null) {
-        activeViewCount += 1;
-      }
-    });
-
-    return activeViewCount;
-  }
-
-  private getHeartbeatIntervalMs(now: number) {
-    let hasFreshView = false;
-
-    this._elementViewState.forEach((viewState) => {
-      if (viewState.enterTimestamp === null) {
-        return;
-      }
-
-      const viewDurationMs = this.getViewDurationMs(viewState, now);
-      if (viewDurationMs < this.extendedHeartbeatThresholdMs) {
-        hasFreshView = true;
-      }
-    });
-
-    return hasFreshView
-      ? this.heartbeatIntervalMs
-      : this.extendedHeartbeatIntervalMs;
-  }
-
-  private stopTrackingVisibleTime(
+  private endSession(
     element: Element,
-    emitFinalHeartbeat: boolean,
+    viewState: ElementViewState,
     now: number
   ) {
-    const viewState = this._elementViewState.get(element);
-
-    if (!viewState) {
-      this.stopHeartbeatIfIdle();
-      return;
-    }
-
-    if (viewState.enterTimestamp === null) {
-      this.stopHeartbeatIfIdle();
-      return;
-    }
-
-    viewState.accumulatedVisibleDurationMs += now - viewState.enterTimestamp;
-    viewState.enterTimestamp = null;
-
-    if (emitFinalHeartbeat) {
-      this.emitViewIfNeeded({
-        element,
-        viewState,
-        now,
-        forceReport: true,
-      });
-    }
-
-    this.stopHeartbeatIfIdle();
-  }
-
-  private getViewDurationMs(viewState: ElementViewState, now: number) {
-    if (viewState.enterTimestamp === null) {
-      return viewState.accumulatedVisibleDurationMs;
-    }
-
-    return (
-      viewState.accumulatedVisibleDurationMs + (now - viewState.enterTimestamp)
-    );
-  }
-
-  private emitViewIfNeeded({
-    element,
-    viewState,
-    now,
-    forceReport,
-  }: EmitViewIfNeededParams) {
-    const viewDurationMs = this.getViewDurationMs(viewState, now);
-
-    viewState.delays.forEach((delay) => {
-      if (viewDurationMs < delay) {
-        return;
-      }
-
-      const lastReportedDurationMs =
-        viewState.lastReportedDurationByDelay.get(delay) ?? 0;
-      const durationDelta = viewDurationMs - lastReportedDurationMs;
-
-      if (durationDelta <= 0) {
-        return;
-      }
-
-      if (!forceReport && durationDelta < this.minimumHeartbeatIncrementMs) {
-        return;
-      }
-
-      this._options.onElementSeen(
-        element,
-        delay,
-        viewDurationMs,
-        viewState.viewId
-      );
-      viewState.lastReportedDurationByDelay.set(delay, viewDurationMs);
+    viewState.pendingStartTimers.forEach((timerId) => {
+      window.clearTimeout(timerId);
     });
+    viewState.pendingStartTimers.clear();
+
+    if (viewState.sessionStartTimestamp === null) {
+      return;
+    }
+
+    const viewDurationMs = now - viewState.sessionStartTimestamp;
+    const viewId = viewState.viewId as string;
+
+    viewState.startedDelays.forEach((delay) => {
+      this._options.onElementSeen(element, delay, viewDurationMs, viewId);
+    });
+
+    viewState.startedDelays.clear();
+    viewState.sessionStartTimestamp = null;
+    viewState.viewId = null;
   }
 }

--- a/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
@@ -165,6 +165,27 @@ describe('Ninetailed core class', () => {
         expect(pageHiddenPlugin.onPageHiddenMock).toHaveBeenCalledTimes(2);
       });
     });
+    it('should not register a beforeunload listener when no plugin is interested in page hidden events', () => {
+      const windowAddEventListenerSpy = jest.spyOn(window, 'addEventListener');
+      const documentAddEventListenerSpy = jest.spyOn(
+        document,
+        'addEventListener'
+      );
+
+      mockProfile([]);
+
+      const registeredWindowEventTypes =
+        windowAddEventListenerSpy.mock.calls.map(([eventType]) => eventType);
+      const registeredDocumentEventTypes =
+        documentAddEventListenerSpy.mock.calls.map(([eventType]) => eventType);
+
+      expect(registeredDocumentEventTypes).toContain('visibilitychange');
+      expect(registeredWindowEventTypes).toContain('pagehide');
+      expect(registeredWindowEventTypes).not.toContain('beforeunload');
+
+      windowAddEventListenerSpy.mockRestore();
+      documentAddEventListenerSpy.mockRestore();
+    });
   });
   describe('Sending of events', () => {
     beforeEach(() => {

--- a/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
@@ -577,6 +577,15 @@ describe('Ninetailed core class', () => {
       ) as ElementSeenPayload[];
 
       expect(payloads[1].viewDurationMs).toBeGreaterThanOrEqual(2_100);
+      // unobserveElement must unobserve before deleting stored payloads, so
+      // the synchronous end event it triggers can still find them.
+      expect(payloads[1]).toEqual(
+        expect.objectContaining({
+          variant: expect.objectContaining({ id: 'variant-id' }),
+          variantIndex: 1,
+          experience: expect.objectContaining({ id: experience.id }),
+        })
+      );
     });
     it('should track component clicks when trackClicks is enabled and the observed element is clickable', async () => {
       const element = document.body.appendChild(
@@ -1034,6 +1043,96 @@ describe('Ninetailed core class', () => {
             }),
           ])
         );
+      });
+
+      it('should resume hover tracking when re-observed while the pointer is still over the element', async () => {
+        const element = document.body.appendChild(
+          document.createElement('div')
+        );
+        jest
+          .spyOn(element, 'matches')
+          .mockImplementation((selector) => selector === ':hover');
+        const hoverPlugin = new TestElementHoverPlugin();
+        const { ninetailed } = mockProfile([hoverPlugin]);
+        const experience = generateExperience();
+        const observe = () =>
+          ninetailed.observeElement(
+            {
+              element,
+              variant: { id: 'variant-id' },
+              variantIndex: 1,
+              experience,
+              componentType: 'Entry',
+            },
+            { trackHovers: true }
+          );
+
+        observe();
+        // Simulate a React re-render that unobserves and re-observes the
+        // same element while the pointer never left it, so mouseenter never
+        // re-fires.
+        ninetailed.unobserveElement(element);
+        observe();
+
+        jest.advanceTimersByTime(2_500);
+        await jest.runAllTimersAsync();
+
+        expect(
+          hoverPlugin.onElementHoveredMock.mock.calls.length
+        ).toBeGreaterThan(0);
+      });
+
+      it('should resume an active hover session after the tab returns to the foreground', async () => {
+        const element = document.body.appendChild(
+          document.createElement('div')
+        );
+        const hoverPlugin = new TestElementHoverPlugin();
+        const { ninetailed } = mockProfile([hoverPlugin]);
+        const experience = generateExperience();
+        ninetailed.observeElement(
+          {
+            element,
+            variant: { id: 'variant-id' },
+            variantIndex: 1,
+            experience,
+            componentType: 'Entry',
+          },
+          { trackHovers: true }
+        );
+
+        element.dispatchEvent(new MouseEvent('mouseenter'));
+        jest.advanceTimersByTime(2_500);
+
+        // The tab hides while the pointer is still over the element: the
+        // session ends (emitting an end event), but mouseleave never fires.
+        jest
+          .spyOn(element, 'matches')
+          .mockImplementation((selector) => selector === ':hover');
+        Object.defineProperty(document, 'visibilityState', {
+          configurable: true,
+          value: 'hidden',
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+
+        Object.defineProperty(document, 'visibilityState', {
+          configurable: true,
+          value: 'visible',
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+
+        jest.advanceTimersByTime(2_500);
+        await jest.runAllTimersAsync();
+
+        const hoverPayloads = hoverPlugin.onElementHoveredMock.mock.calls.map(
+          ([payload]) => payload as ElementHoveredPayload
+        );
+        const hoverIds = new Set(
+          hoverPayloads.map((payload) => payload.hoverId)
+        );
+
+        // One start+end pair for the session ended on hide, and a second,
+        // distinct hoverId for the session resumed on foreground.
+        expect(hoverIds.size).toBe(2);
       });
     });
 

--- a/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
@@ -308,7 +308,7 @@ describe('Ninetailed core class', () => {
       });
       // Simulate the intersection of the element with the viewport
       intersect(element, true);
-      // Advance to the first heartbeat where all default thresholds are eligible.
+      // Advance past the default view-tracking threshold so the start event fires.
       jest.advanceTimersByTime(2_100);
       await waitFor(() => {
         expect(testPlugin.onTrackExperienceMock).toHaveBeenCalledTimes(1);
@@ -489,8 +489,8 @@ describe('Ninetailed core class', () => {
 
       intersect(element, true);
       jest.advanceTimersByTime(2_100);
-      // No further events should be emitted while the view stays active,
-      // since there is no more periodic heartbeat polling.
+      // No further events should be emitted while the view stays active;
+      // only the start event fires until the session actually ends.
       jest.advanceTimersByTime(60_000);
       intersect(element, false);
       jest.runAllTimers();

--- a/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
@@ -507,7 +507,7 @@ describe('Ninetailed core class', () => {
       expect(payloads[1].viewDurationMs).toBeGreaterThanOrEqual(62_100);
       expect(payloads[0].viewId).toBe(payloads[1].viewId);
     });
-    it('should not emit a view end event when the element never met the view threshold', () => {
+    it('should not emit a view end event when the element never met the view threshold', async () => {
       const element = document.body.appendChild(document.createElement('div'));
       const seenPlugin = new TestElementSeenPlugin();
       const { ninetailed } = mockProfile([seenPlugin]);
@@ -524,7 +524,7 @@ describe('Ninetailed core class', () => {
       intersect(element, true);
       jest.advanceTimersByTime(250);
       intersect(element, false);
-      jest.runAllTimers();
+      await jest.runAllTimersAsync();
 
       expect(seenPlugin.onElementSeenMock).toHaveBeenCalledTimes(0);
     });
@@ -841,7 +841,7 @@ describe('Ninetailed core class', () => {
         expect(hoverPayloads[0].hoverId).toBe(hoverPayloads[1].hoverId);
       });
 
-      it('should not track component hovers when hover duration is below the minimum threshold', () => {
+      it('should not track component hovers when hover duration is below the minimum threshold', async () => {
         const element = document.body.appendChild(
           document.createElement('div')
         );
@@ -861,7 +861,7 @@ describe('Ninetailed core class', () => {
         element.dispatchEvent(new MouseEvent('mouseenter'));
         jest.advanceTimersByTime(1);
         element.dispatchEvent(new MouseEvent('mouseleave'));
-        jest.runAllTimers();
+        await jest.runAllTimersAsync();
         expect(hoverPlugin.onElementHoveredMock).toHaveBeenCalledTimes(0);
       });
 

--- a/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.spec.ts
@@ -473,7 +473,7 @@ describe('Ninetailed core class', () => {
       expect(uniqueViewIds.size).toBe(2);
       expect(Math.max(...durations)).toBeLessThan(4_000);
     });
-    it('should switch to a slower heartbeat cadence after long views', async () => {
+    it('should emit exactly a start and an end event for a single view session', async () => {
       const element = document.body.appendChild(document.createElement('div'));
       const seenPlugin = new TestElementSeenPlugin();
       const { ninetailed } = mockProfile([seenPlugin]);
@@ -488,26 +488,74 @@ describe('Ninetailed core class', () => {
       });
 
       intersect(element, true);
-      jest.advanceTimersByTime(10_500);
-      await waitFor(() => {
-        expect(seenPlugin.onElementSeenMock.mock.calls.length).toBeGreaterThan(
-          0
-        );
-      });
-      const callsBeforeSlowCadence =
-        seenPlugin.onElementSeenMock.mock.calls.length;
+      jest.advanceTimersByTime(2_100);
+      // No further events should be emitted while the view stays active,
+      // since there is no more periodic heartbeat polling.
+      jest.advanceTimersByTime(60_000);
+      intersect(element, false);
+      jest.runAllTimers();
 
-      jest.advanceTimersByTime(9_000);
-      expect(seenPlugin.onElementSeenMock.mock.calls.length).toBe(
-        callsBeforeSlowCadence
-      );
-
-      jest.advanceTimersByTime(1_500);
       await waitFor(() => {
-        expect(seenPlugin.onElementSeenMock.mock.calls.length).toBeGreaterThan(
-          callsBeforeSlowCadence
-        );
+        expect(seenPlugin.onElementSeenMock).toHaveBeenCalledTimes(2);
       });
+
+      const payloads = seenPlugin.onElementSeenMock.mock.calls.map(
+        ([payload]) => payload
+      ) as ElementSeenPayload[];
+
+      expect(payloads[0].viewDurationMs).toBe(0);
+      expect(payloads[1].viewDurationMs).toBeGreaterThanOrEqual(62_100);
+      expect(payloads[0].viewId).toBe(payloads[1].viewId);
+    });
+    it('should not emit a view end event when the element never met the view threshold', () => {
+      const element = document.body.appendChild(document.createElement('div'));
+      const seenPlugin = new TestElementSeenPlugin();
+      const { ninetailed } = mockProfile([seenPlugin]);
+      getObserverOf(element);
+      const experience = generateExperience();
+      ninetailed.observeElement({
+        element,
+        variant: { id: 'variant-id' },
+        variantIndex: 1,
+        experience,
+        componentType: 'Entry',
+      });
+
+      intersect(element, true);
+      jest.advanceTimersByTime(250);
+      intersect(element, false);
+      jest.runAllTimers();
+
+      expect(seenPlugin.onElementSeenMock).toHaveBeenCalledTimes(0);
+    });
+    it('should emit a view end event when unobserveElement is called mid-session', async () => {
+      const element = document.body.appendChild(document.createElement('div'));
+      const seenPlugin = new TestElementSeenPlugin();
+      const { ninetailed } = mockProfile([seenPlugin]);
+      getObserverOf(element);
+      const experience = generateExperience();
+      ninetailed.observeElement({
+        element,
+        variant: { id: 'variant-id' },
+        variantIndex: 1,
+        experience,
+        componentType: 'Entry',
+      });
+
+      intersect(element, true);
+      jest.advanceTimersByTime(2_100);
+      ninetailed.unobserveElement(element);
+      jest.runAllTimers();
+
+      await waitFor(() => {
+        expect(seenPlugin.onElementSeenMock).toHaveBeenCalledTimes(2);
+      });
+
+      const payloads = seenPlugin.onElementSeenMock.mock.calls.map(
+        ([payload]) => payload
+      ) as ElementSeenPayload[];
+
+      expect(payloads[1].viewDurationMs).toBeGreaterThanOrEqual(2_100);
     });
     it('should track component clicks when trackClicks is enabled and the observed element is clickable', async () => {
       const element = document.body.appendChild(
@@ -746,7 +794,7 @@ describe('Ninetailed core class', () => {
         ).toBeGreaterThanOrEqual(10_000);
       });
 
-      it('should emit a final hover heartbeat on mouseleave for unsent hover duration', async () => {
+      it('should emit exactly a start and an end event for a single hover session', async () => {
         const element = document.body.appendChild(
           document.createElement('div')
         );
@@ -771,9 +819,7 @@ describe('Ninetailed core class', () => {
         jest.runAllTimers();
 
         await waitFor(() => {
-          expect(
-            hoverPlugin.onElementHoveredMock.mock.calls.length
-          ).toBeGreaterThan(1);
+          expect(hoverPlugin.onElementHoveredMock).toHaveBeenCalledTimes(2);
         });
 
         const hoverPayloads = hoverPlugin.onElementHoveredMock.mock.calls.map(
@@ -790,12 +836,9 @@ describe('Ninetailed core class', () => {
           );
         });
 
-        const hoverDurations = hoverPayloads.map(
-          (hoverPayload) => hoverPayload.hoverDurationMs
-        );
-
-        expect(hoverDurations).toEqual(expect.arrayContaining([2_000]));
-        expect(Math.max(...hoverDurations)).toBeGreaterThan(2_000);
+        expect(hoverPayloads[0].hoverDurationMs).toBe(0);
+        expect(hoverPayloads[1].hoverDurationMs).toBeGreaterThanOrEqual(2_500);
+        expect(hoverPayloads[0].hoverId).toBe(hoverPayloads[1].hoverId);
       });
 
       it('should not track component hovers when hover duration is below the minimum threshold', () => {

--- a/packages/sdks/javascript/src/lib/Ninetailed.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.ts
@@ -1180,9 +1180,17 @@ export class Ninetailed implements NinetailedInstance {
       }
 
       this.elementSeenObserver.resumeActiveSessions();
+      this.elementHoverObserver.resumeActiveSessions();
     });
 
     window.addEventListener('pagehide', dispatchPageHidden);
-    window.addEventListener('beforeunload', dispatchPageHidden);
+
+    // Registering a beforeunload listener makes browsers (notably Firefox)
+    // treat the page as bfcache-ineligible, hurting back/forward navigation
+    // performance. Only pay that cost when a plugin actually needs the
+    // PAGE_HIDDEN dispatch beforeunload provides as a pagehide fallback.
+    if (hasPluginsInterestedInHiddenPage) {
+      window.addEventListener('beforeunload', dispatchPageHidden);
+    }
   };
 }

--- a/packages/sdks/javascript/src/lib/Ninetailed.ts
+++ b/packages/sdks/javascript/src/lib/Ninetailed.ts
@@ -323,13 +323,7 @@ export class Ninetailed implements NinetailedInstance {
     });
     this.componentViewTrackingThreshold = componentViewTrackingThreshold;
 
-    const hasPluginsInterestedInHiddenPage = this.plugins.some(
-      isInterestedInHiddenPage
-    );
-
-    if (hasPluginsInterestedInHiddenPage) {
-      this.onVisibilityChange();
-    }
+    this.onVisibilityChange();
 
     this.registerWindowHandlers();
   }
@@ -602,10 +596,13 @@ export class Ninetailed implements NinetailedInstance {
   }
 
   public unobserveElement = (element: Element) => {
-    this.observedElements.delete(element);
+    // Unobserve before deleting stored payloads: unobserving a view/hover
+    // session in progress synchronously dispatches a final end event, which
+    // looks up the element's payloads to build its dispatch.
     this.elementSeenObserver.unobserve(element);
     this.elementClickObserver.unobserve(element);
     this.elementHoverObserver.unobserve(element);
+    this.observedElements.delete(element);
   };
 
   private onElementSeen = (
@@ -1146,16 +1143,43 @@ export class Ninetailed implements NinetailedInstance {
       return;
     }
 
+    const hasPluginsInterestedInHiddenPage = this.plugins.some(
+      isInterestedInHiddenPage
+    );
+
+    const endActiveViewAndHoverSessions = () => {
+      this.elementSeenObserver.endActiveSessions();
+      this.elementHoverObserver.endActiveSessions();
+    };
+
     const dispatchPageHidden = () => {
-      this.elementSeenObserver.flushActiveViews();
-      this.elementHoverObserver.flushActiveHovers();
-      this.instance.dispatch({ type: PAGE_HIDDEN });
+      endActiveViewAndHoverSessions();
+
+      if (hasPluginsInterestedInHiddenPage) {
+        this.instance.dispatch({ type: PAGE_HIDDEN });
+      }
     };
 
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'hidden') {
-        dispatchPageHidden();
+        endActiveViewAndHoverSessions();
+
+        if (hasPluginsInterestedInHiddenPage) {
+          // Ending active sessions dispatches their final view/hover events,
+          // which plugins process through an async (microtask-based) chain
+          // before queueing them. The tab staying open means we can afford
+          // to wait a tick for that chain to settle so PAGE_HIDDEN's flush
+          // doesn't ship a beacon that's missing those final events. This
+          // deferral is unsafe on pagehide/beforeunload (the page may be
+          // torn down before a timer fires), so those stay synchronous.
+          setTimeout(() => {
+            this.instance.dispatch({ type: PAGE_HIDDEN });
+          }, 0);
+        }
+        return;
       }
+
+      this.elementSeenObserver.resumeActiveSessions();
     });
 
     window.addEventListener('pagehide', dispatchPageHidden);


### PR DESCRIPTION
- Replaced `view` & `hover` heartbeats with `start`/`end` events to significantly reduce number of events
- Adjusted `page-hidden` behaviour to ensure that any existing events are correctly flushed and new events are generated when a tab is resumed