### PR TITLE
chore(ci): migrate Doppler auth to OIDC via secrets-fetch-action

### DIFF
--- a/.github/workflows/lint_build_test_all.yaml
+++ b/.github/workflows/lint_build_test_all.yaml
@@ -73,6 +73,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read # required by nrwl/nx-set-shas to query the Actions API
+      id-token: write # required to obtain the OIDC JWT for Doppler auth
     steps:
       - name: Checkout Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -95,26 +99,32 @@ jobs:
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
 
-      - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4
+      - name: Fetch Doppler secrets
+        uses: dopplerhq/secrets-fetch-action@451892f16195f9ac360e1a5bcbf0b5fd0e957534 # v2.0.0
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_IDENTITY_ID }}
+          doppler-project: experience-js-sdks
+          doppler-config: dev
+          inject-env-vars: true
 
       - name: Test 🧪
         run: >
-          doppler run --mount .env -- pnpm nx affected --target=test
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          pnpm nx affected --target=test
 
       - name: Generated package snapshots 🧪
         run: >
-          doppler run --mount .env -- pnpm nx run tests-generated-packages:test
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          pnpm nx run tests-generated-packages:test
 
   build:
     name: Build 📦
     runs-on: ubuntu-latest
     needs: setup
     timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read # required by nrwl/nx-set-shas to query the Actions API
+      id-token: write # required to obtain the OIDC JWT for Doppler auth
     steps:
       - name: Checkout Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -137,14 +147,18 @@ jobs:
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
 
-      - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4
+      - name: Fetch Doppler secrets
+        uses: dopplerhq/secrets-fetch-action@451892f16195f9ac360e1a5bcbf0b5fd0e957534 # v2.0.0
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_IDENTITY_ID }}
+          doppler-project: experience-js-sdks
+          doppler-config: dev
+          inject-env-vars: true
 
       - name: Build 📦
         run: >
-          doppler run --mount .env -- pnpm nx affected --target=build
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          pnpm nx affected --target=build
 
   license-check:
     name: License check 📄

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,6 +36,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      id-token: write # required to obtain the OIDC JWT for Doppler auth
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -56,14 +57,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4
+      - name: Fetch Doppler secrets
+        uses: dopplerhq/secrets-fetch-action@451892f16195f9ac360e1a5bcbf0b5fd0e957534 # v2.0.0
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_IDENTITY_ID }}
+          doppler-project: experience-js-sdks
+          doppler-config: dev
+          inject-env-vars: true
 
       - name: Build 📦
         run: >
-          doppler run --mount .env -- pnpm nx run-many --target=build
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          pnpm nx run-many --target=build
 
   lint:
     name: Lint 🎨
@@ -109,6 +114,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      id-token: write # required to obtain the OIDC JWT for Doppler auth
     steps:
       - name: Checkout Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -129,14 +135,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4
+      - name: Fetch Doppler secrets
+        uses: dopplerhq/secrets-fetch-action@451892f16195f9ac360e1a5bcbf0b5fd0e957534 # v2.0.0
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_IDENTITY_ID }}
+          doppler-project: experience-js-sdks
+          doppler-config: dev
+          inject-env-vars: true
 
       - name: Test 🧪
         run: >
-          doppler run --mount .env -- pnpm nx run-many --target=test
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          pnpm nx run-many --target=test
 
   license-check:
     name: License check 📄
@@ -212,16 +222,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4
+      - name: Fetch Doppler secrets
+        uses: dopplerhq/secrets-fetch-action@451892f16195f9ac360e1a5bcbf0b5fd0e957534 # v2.0.0
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_IDENTITY_ID }}
+          doppler-project: experience-js-sdks
+          doppler-config: dev
+          inject-env-vars: true
 
       - name: Echo github event release metadatas
         run: echo "$JOB_CONTEXT"
         env:
           JOB_CONTEXT: ${{ toJson(github.event.release) }}
 
-      - run: doppler run --mount .env -- ./tools/bump_and_publish_sdks.sh
+      - run: ./tools/bump_and_publish_sdks.sh
         env:
           GITHUB_TAG: ${{ github.event.release.tag_name }}
-          # we run nx build in the script, so we might need some env vars
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}


### PR DESCRIPTION
## What

Migrates CI Doppler authentication from a **static \`DOPPLER_TOKEN\` service token + \`dopplerhq/cli-action\`** to **\`dopplerhq/secrets-fetch-action\` using a Service Account Identity via OIDC** (workload identity — no static token stored in GitHub).

## Changes

- **Main Pipeline** (\`lint_build_test_all.yaml\`): \`tests\` and \`build\` jobs.
- **Publish** (\`publish.yaml\`): \`build\`, \`tests\`, and \`publish\` jobs.

For each secret-consuming job:
- Added \`id-token: write\` permission (required for GitHub to mint the OIDC JWT).
- Replaced the \`Install Doppler CLI\` step with \`dopplerhq/secrets-fetch-action\` (OIDC mode), fetching \`experience-js-sdks/dev\` and injecting secrets as env vars.
- Dropped the \`doppler run --mount .env --\` wrapper — commands now run directly and inherit the injected env vars.
- Removed \`dopplerhq/cli-action\` entirely.

## Doppler / GitHub setup (already done)

- Created an OIDC **Service Account Identity** on the \`Github actions ninetailed-inc/experience.js\` service account:
  - discovery URL: \`https://token.actions.githubusercontent.com\`
  - \`aud\`: \`https://github.com/ninetailed-inc\`
  - \`sub\` (wildcard): \`repo:ninetailed-inc/experience.js:*\`
- Added repo **variable** \`DOPPLER_IDENTITY_ID\` (non-secret config value).
- Action pinned to commit SHA \`451892f\` (\`v2.0.0\`), matching repo convention.

## Follow-up (owner)

- [ ] Remove the \`DOPPLER_TOKEN\` GitHub Actions secret after this merges and CI is green.

## Notes

- Local dev flow in \`CONTRIBUTING.md\` (\`doppler login\` + \`doppler secrets download\`) is unchanged.
- If the first run 403s on secret fetch, the service account needs read access granted to the \`experience-js-sdks/dev\` config.