### PR TITLE
docs: add AI harness readiness guidance [NT-4002]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## Repository purpose
+
+Public pnpm/Nx monorepo containing legacy Ninetailed SDKs, plugins, utilities, playgrounds, and migration tooling.
+
+## Working rules
+
+- Read README.md and the nearest package or project documentation before changing behavior.
+- Keep changes scoped to the component or example that owns the behavior.
+- Do not commit credentials, tokens, generated secrets, or local environment files.
+- Treat checked-in manifests and lockfiles as the source of truth for tooling.
+- Update documentation when commands, layout, or public behavior changes.
+- Preserve existing generated files and regenerate them only through their owning command.
+- Run the smallest relevant validation first, then the repository-level checks.
+- Call out missing credentials or external services instead of bypassing their checks.
+- Keep public documentation free of private links, credentials, and non-public context.
+- Record durable architectural choices under docs/ADRs/.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,25 @@
+# Architecture
+
+## Purpose
+
+Public pnpm/Nx monorepo containing legacy Ninetailed SDKs, plugins, utilities, playgrounds, and migration tooling.
+
+## Main areas
+
+- packages/sdks contains SDK packages.
+- packages/plugins contains optional integrations.
+- packages/utils contains shared utilities.
+- packages/playgrounds exercises integrations; tools/ contains scripts and AI migration utilities.
+
+## Change flow
+
+Repository manifests and checked-in configuration define how source becomes a build, package, report, example, or documentation artifact. Keep changes inside the owning area and follow explicit dependencies rather than copying behavior between components.
+
+## Boundaries
+
+External services, credentials, and deployment environments are not represented by source code alone. Local validation should use documented fixtures or configuration and must not embed secrets.
+
+## Failure and verification
+
+Start with the narrowest affected command, inspect its direct inputs, and expand to repository-level validation. If a required external system is unavailable, record that verification gap instead of claiming success.
+

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,4 +22,3 @@ External services, credentials, and deployment environments are not represented 
 ## Failure and verification
 
 Start with the narrowest affected command, inspect its direct inputs, and expand to repository-level validation. If a required external system is unavailable, record that verification gap instead of claiming success.
-

--- a/docs/ADRs/0001-manage-the-sdk-family-as-an-nx-monorepo.md
+++ b/docs/ADRs/0001-manage-the-sdk-family-as-an-nx-monorepo.md
@@ -1,0 +1,17 @@
+# Manage the SDK family as an Nx monorepo
+
+- Status: Accepted
+- Scope: Ninetailed Experience.js
+
+## Context
+
+The SDK, plugins, utilities, tests, and playgrounds evolve together and share build conventions.
+
+## Decision
+
+Use pnpm workspaces with Nx targets to coordinate builds, tests, linting, and caching across packages.
+
+## Consequences
+
+Package changes should be validated through affected Nx targets, and cross-package contracts must remain compatible.
+

--- a/docs/ADRs/0001-manage-the-sdk-family-as-an-nx-monorepo.md
+++ b/docs/ADRs/0001-manage-the-sdk-family-as-an-nx-monorepo.md
@@ -14,4 +14,3 @@ Use pnpm workspaces with Nx targets to coordinate builds, tests, linting, and ca
 ## Consequences
 
 Package changes should be validated through affected Nx targets, and cross-package contracts must remain compatible.
-


### PR DESCRIPTION
## Summary

- add repository-specific AI harness guidance in `AGENTS.md`, `ARCHITECTURE.md`, and `CONTRIBUTING.md`
- record factual architectural decisions under `docs/ADRs/`
- keep this documentation-only: no catalog metadata or Agents Kit consumer was added

## Why

This prepares the repository for the AI Harness governance controls tracked by NT-4002 while preserving its existing runtime and tooling.

## Validation

- governance document thresholds and ADR discovery passed
- referenced paths and whitespace checks passed

Ticket: [NT-4002](https://contentful.atlassian.net/browse/NT-4002)


[NT-4002]: https://contentful.atlassian.net/browse/NT-4002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ